### PR TITLE
Add ADB PTT injection for docker-android targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <h1>ZPTTLink</h1>
 
-<p>ZPTTLink is an open-source, cross-platform application that bridges Zello (running inside <a href="https://www.bluestacks.com/">BlueStacks</a> or <a href="https://waydro.id/">Waydroid</a>) with radio gateway hardware like the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>. It enables seamless Push-to-Talk (PTT) control and audio routing, allowing users to link RF radios to Zello using only a computer.</p>
+<p>ZPTTLink is an open-source, cross-platform application that bridges Zello with radio gateway hardware like the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>. It enables seamless Push-to-Talk (PTT) control and audio routing, allowing users to link RF radios to Zello using only a computer. Zello itself can run inside <a href="https://www.bluestacks.com/">BlueStacks</a> (macOS), <a href="https://waydro.id/">Waydroid</a> (Linux), or a dockerized Android emulator such as <a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a> or <a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a> — see <a href="#android-runtime-targets">Android Runtime Targets</a> below for how PTT reaches each one.</p>
 
 <p>This tool is ideal for GMRS and ham radio operators, emergency communications volunteers, and hobbyists who want to build a software-based radio gateway.</p>
 
@@ -58,10 +58,18 @@
 <h2>Features</h2>
 
 <ul>
-  <li>Compatible with AIOC, CM108-based, and other USB serial/audio radio cables</li>
-  <li>Detects PTT signals via USB serial</li>
-  <li>Simulates keypresses or mouse events to trigger Zello’s Push-to-Talk</li>
-  <li>Cross-platform support for Windows, macOS, and Linux</li>
+  <li>Compatible with AIOC, CM108/CM119-based, DigiRig, and other USB serial/audio radio cables</li>
+  <li>Detects PTT signals via USB serial (DigiRig DTR/RTS) or USB HID GPIO (CM108/CM119)</li>
+  <li><strong>Multiple ways to trigger PTT in the Zello target, selectable via <code>injection_mode</code>:</strong>
+    <ul>
+      <li><code>pynput</code> — standard host keyboard injection (X11 / macOS / Windows)</li>
+      <li><code>ydotool</code> — Linux <code>/dev/uinput</code> injection; used automatically on a detected Wayland session, where host key injection is normally blocked</li>
+      <li><code>adb</code> — sends <code>input keyevent</code> directly into an Android target over ADB; the mechanism for <a href="#android-runtime-targets">docker-android targets</a>, since they have no host window to inject into at all</li>
+      <li><code>auto</code> (default) — picks pynput or ydotool automatically based on the detected session</li>
+    </ul>
+  </li>
+  <li>Direct hardware PTT via serial DTR/RTS or CM108 GPIO, independent of key injection entirely — the most reliable option when the radio, not the app, is the thing you need to key</li>
+  <li>Cross-platform support for Windows, macOS, and Linux (including Raspberry Pi)</li>
   <li><strong>Two operating modes:</strong>
     <ul>
       <li>Terminal (CLI) mode for lightweight deployments and automation</li>
@@ -76,6 +84,7 @@
       <li>Radio-style push-to-talk button</li>
       <li>Runtime start/stop controls</li>
       <li>Config editor with save button</li>
+      <li>Android target / injection mode selector, with an ADB serial field for docker-android targets</li>
     </ul>
   </li>
   <li>Audio routing via <a href="https://vb-audio.com/Cable/">VB-Cable (Windows)</a>, <a href="https://existential.audio/blackhole/">BlackHole (macOS)</a>, or <a href="https://www.alsa-project.org/wiki/Loopback_Device">ALSA Loopback (Linux)</a></li>
@@ -84,9 +93,11 @@
 <h2>Requirements</h2>
 
 <ul>
-  <li>AIOC or compatible USB PTT/audio interface</li>
+  <li>AIOC, CM108/CM119, or compatible USB PTT/audio interface</li>
   <li>Python 3.8 or newer</li>
-  <li>Zello installed inside <a href="https://www.bluestacks.com/">BlueStacks</a> or <a href="https://waydro.id/">Waydroid</a></li>
+  <li>Zello installed inside <a href="https://www.bluestacks.com/">BlueStacks</a>, <a href="https://waydro.id/">Waydroid</a>, or a <a href="#android-runtime-targets">docker-android</a> container</li>
+  <li><strong>For <code>injection_mode: adb</code> only:</strong> <a href="https://developer.android.com/tools/adb">Android platform-tools</a> (<code>adb</code>) on the host</li>
+  <li><strong>For Wayland hosts only:</strong> <a href="https://github.com/ReimuNotMoe/ydotool">ydotool</a> + a running <code>ydotoold</code>, used automatically as the key-injection fallback</li>
 </ul>
 
 <h3>Python Dependencies</h3>
@@ -97,10 +108,10 @@
 </code></pre>
 
 <ul>
-  <li><strong>Core:</strong> pyserial, pynput, sounddevice, numpy, loguru, platformdirs</li>
+  <li><strong>Core:</strong> pyserial, pynput, sounddevice, numpy, loguru, platformdirs, pyusb, PySide6</li>
   <li><strong>Windows:</strong> pycaw</li>
   <li><strong>macOS:</strong> pyobjc</li>
-  <li><strong>Linux:</strong> pulsectl, pyalsa</li>
+  <li><strong>Linux:</strong> pulsectl</li>
 </ul>
 
 <h3>Linux Notes</h3>
@@ -199,9 +210,80 @@ source venv/bin/activate</code></pre>
   <li>Raspberry Pi</li>
 </ul>
 
+<h2>Android Runtime Targets</h2>
+
+<p>Zello can run in four different places relative to ZPTTLink. Which one you're using determines how PTT actually reaches it — set <code>injection_mode</code> (and <code>adb_serial</code>, if applicable) accordingly.</p>
+
+<h3>BlueStacks (macOS)</h3>
+
+<ul>
+  <li><code>injection_mode: pynput</code> (default on macOS)</li>
+  <li>Install BlueStacks, install Zello inside it, and set Zello's PTT hotkey to match <code>ptt_hotkey</code> in your config (default <code>F9</code>)</li>
+  <li>Route audio through <a href="https://existential.audio/blackhole/">BlackHole</a>: BlueStacks' input device set to the BlackHole loopback, ZPTTLink's <code>audio_output_index</code> pointed at the same BlackHole device</li>
+  <li>macOS requires granting Accessibility permission to the terminal/app running ZPTTLink for pynput key injection to work at all (System Settings → Privacy & Security → Accessibility)</li>
+</ul>
+
+<h3>Waydroid (Linux)</h3>
+
+<ul>
+  <li>On an X11 session: <code>injection_mode: pynput</code> works the same as BlueStacks</li>
+  <li>On a Wayland session (common on modern distros): <code>injection_mode: auto</code> switches to <code>ydotool</code> automatically — install <code>ydotool</code> and run <code>ydotoold</code> as a service first</li>
+  <li><strong>Known limitation:</strong> Waydroid runs Android inside its own container with its own input stack. Even when <code>ydotool</code> successfully injects a key on the host, Waydroid does not reliably forward that synthetic event into the Android session — this is a Waydroid input-isolation limitation, not something ZPTTLink controls. If key injection doesn't reach Zello inside Waydroid, ADB is usually more reliable (Waydroid exposes an ADB target once <code>waydroid shell settings put global adb_enabled 1</code> or equivalent is configured — see Waydroid's own docs) — set <code>injection_mode: adb</code> and point <code>adb_serial</code> at it, same as the docker-android targets below</li>
+  <li>Route audio through <a href="https://www.alsa-project.org/wiki/Loopback_Device">ALSA Loopback</a> or PulseAudio's <code>module-loopback</code>, since Waydroid can be configured to use the host's PulseAudio/PipeWire server directly</li>
+</ul>
+
+<h3>docker-android (budtmo or HQarroum)</h3>
+
+<p>Both <a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a> and <a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a> run a real Android <strong>emulator</strong> inside a container, controlled over ADB (budtmo also adds a noVNC web UI). ZPTTLink talks to Zello inside either one the same way: over ADB.</p>
+
+<pre><code># budtmo/docker-android — noVNC on 6080, ADB on 5555
+docker run -d -p 6080:6080 -p 5555:5555 \
+  -e EMULATOR_DEVICE="Samsung Galaxy S10" -e WEB_VNC=true \
+  budtmo/docker-android
+
+# HQarroum/docker-android — ADB on 5555
+docker run -d -p 5555:5555 hqarroum/docker-android
+</code></pre>
+
+<ol>
+  <li>Connect and install Zello inside the emulator (once, per container):
+    <pre><code>adb connect 127.0.0.1:5555
+adb install /path/to/zello.apk</code></pre>
+  </li>
+  <li>Open Zello inside the emulator (via budtmo's noVNC at <code>http://localhost:6080</code>, or <code>scrcpy</code> against the ADB target) and set Zello's PTT hotkey mode to <strong>Toggle</strong>, not Hold — see below for why.</li>
+  <li>Configure ZPTTLink:
+    <pre><code>{
+  "injection_mode": "adb",
+  "adb_serial": "127.0.0.1:5555",
+  "ptt_hotkey": "F9"
+}</code></pre>
+    or via the CLI: <code>python -m zpttlink --injection-mode adb --adb-serial 127.0.0.1:5555</code>, or in the GUI's "Android Target" panel.
+  </li>
+</ol>
+
+<p><strong>Why Toggle, not Hold:</strong> Android's <code>adb shell input keyevent</code> dispatches a key press and release together as a single, instantaneous event — there is no way to hold a key down over ADB the way a real keyboard (or DTR/RTS) can. ZPTTLink's ADB mode sends one tap when the radio's PTT goes down, and deliberately does nothing when it goes back up. This matches Zello's <strong>Toggle</strong> hotkey mode (tap once to start transmitting, tap again to stop) but will not work correctly with Zello's <strong>Hold</strong> mode, since there's no way to release a key ZPTTLink never truly held.</p>
+
+<p><strong>Audio is not bridged for either docker-android project.</strong> Both run headless by default — HQarroum's image explicitly starts the emulator with <code>-no-audio</code>, and budtmo's does not document any audio passthrough at all. That means ZPTTLink's audio bridge (mic-in → radio-out) has nothing to connect to inside a stock container: there is no virtual sound device reachable from the host. Getting audio into the emulator requires routing PulseAudio over the network into the container yourself — for example, enabling <code>module-native-protocol-tcp</code> on the host's PulseAudio server and pointing the emulator's own <code>-audio-backend</code>/<code>EXTRA_FLAGS</code> at it (see each project's <code>EXTRA_FLAGS</code> environment variable). Exact flags depend on the emulator/QEMU version bundled in the image, so treat this as a starting point, not a copy-paste recipe — consult the specific image's own issues/docs for the audio flags it currently supports. Until that's wired up, these two targets are useful for <strong>testing the ADB PTT trigger path</strong> with Zello's Toggle mode, not for a working end-to-end audio bridge.</p>
+
 <h2>How It Works</h2>
 
-<p>ZPTTLink listens to the USB serial signal from your radio cable. When activated, it simulates a keypress or mouse event to trigger Zello in BlueStacks or Waydroid. Audio from your radio is routed using the virtual audio driver, creating a seamless RF-to-Zello link.</p>
+<p>ZPTTLink listens for a PTT signal from your radio interface — either a serial control line (DigiRig DTR/RTS) or a USB HID GPIO line (CM108/CM119). When it fires, ZPTTLink does two things in parallel:</p>
+
+<ol>
+  <li><strong>Triggers Zello's PTT</strong>, using whichever <code>injection_mode</code> the target needs: a simulated keypress (pynput on X11/macOS/Windows, ydotool on Wayland), or an ADB <code>input keyevent</code> tap for a docker-android/ADB-reachable target. See <a href="#android-runtime-targets">Android Runtime Targets</a> for which one applies to your setup.</li>
+  <li><strong>Keys the radio directly</strong> via serial DTR/RTS or CM108 GPIO, independent of whether the key injection actually reached Zello — this is the deterministic path the project name refers to.</li>
+</ol>
+
+<p>Microphone/Zello audio is routed to the radio's audio output via a virtual audio driver, creating the RF-to-Zello link.</p>
+
+<h2>Known Limitations</h2>
+
+<ul>
+  <li><strong>TX-only.</strong> ZPTTLink currently bridges audio from Zello/microphone to the radio. It does not yet route received radio audio back into Zello as a virtual microphone — that RX path is unbuilt.</li>
+  <li><strong>ADB PTT is edge-triggered, not press-and-hold.</strong> See <a href="#android-runtime-targets">Android Runtime Targets</a> — it requires Zello's hotkey mode set to Toggle, not Hold.</li>
+  <li><strong>No audio bridge into docker-android by default.</strong> Both supported docker-android images run headless with no audio passthrough out of the box; wiring that up is a manual PulseAudio-over-network step outside ZPTTLink's control.</li>
+  <li><strong>Waydroid input isolation.</strong> Synthetic key events (ydotool or otherwise) injected on the host are not guaranteed to reach an app running inside Waydroid's container; ADB is the more reliable fallback there too.</li>
+</ul>
 
 <h2>License</h2>
 
@@ -223,6 +305,9 @@ Full license text: https://opensource.org/licenses/MIT
   <li><a href="https://github.com/alsa-project/alsa-utils">ALSA Utils / Loopback (Linux)</a></li>
   <li><a href="https://github.com/bluestacks">BlueStacks</a></li>
   <li><a href="https://github.com/waydroid">Waydroid</a></li>
+  <li><a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a></li>
+  <li><a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a></li>
+  <li><a href="https://github.com/ReimuNotMoe/ydotool">ydotool</a></li>
   <li><a href="https://github.com/vb-audio-software">VB-Audio (VB-Cable)</a></li>
 </ul>
 

--- a/zpttlink/gui.py
+++ b/zpttlink/gui.py
@@ -82,19 +82,48 @@ def detect_waydroid_linux() -> bool:
     return shutil.which("waydroid") is not None
 
 
+def detect_docker_android() -> Optional[str]:
+    """Best-effort detection of a running docker-android container (budtmo or HQarroum
+    images), purely informational — ADB injection still requires configuring adb_serial
+    manually, since the container's mapped host:port isn't discoverable from image name alone.
+    """
+    if shutil.which("docker") is None:
+        return None
+    try:
+        out = subprocess.run(
+            ["docker", "ps", "--format", "{{.Image}}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if out.returncode != 0:
+            return None
+        images = out.stdout.lower()
+        if "budtmo/docker-android" in images:
+            return "docker-android (budtmo)"
+        if "docker-android" in images or "hqarroum" in images:
+            return "docker-android (HQarroum)"
+    except Exception:
+        return None
+    return None
+
+
 def detect_android_runtime() -> str:
     system = platform.system()
+    found = []
 
-    if system == "Darwin":
-        return "BlueStacks" if detect_bluestacks_mac() else "none detected"
+    if system == "Darwin" and detect_bluestacks_mac():
+        found.append("BlueStacks")
+    if system == "Linux" and detect_waydroid_linux():
+        found.append("Waydroid")
 
-    if system == "Linux":
-        return "Waydroid" if detect_waydroid_linux() else "none detected"
+    docker_target = detect_docker_android()
+    if docker_target:
+        found.append(docker_target)
 
-    if system == "Windows":
-        return "none detected"
-
-    return "n/a"
+    if found:
+        return " + ".join(found)
+    return "none detected" if system in {"Darwin", "Linux", "Windows"} else "n/a"
 
 
 def detect_audio_backend() -> str:
@@ -262,6 +291,7 @@ class MainWindow(QMainWindow):
         top.addWidget(self._build_audio_group(), 0, 1)
         top.addWidget(self._build_runtime_group(), 1, 0)
         top.addWidget(self._build_status_group(), 1, 1)
+        top.addWidget(self._build_android_target_group(), 2, 0, 1, 2)
 
         controls = QHBoxLayout()
         self.btn_save = QPushButton("Save Config")
@@ -316,6 +346,59 @@ class MainWindow(QMainWindow):
         layout.addRow("", self.chk_ignore_initial_ptt)
 
         return group
+
+    def _build_android_target_group(self):
+        group = QGroupBox("Android Target (Zello host)")
+        layout = QFormLayout(group)
+
+        self.injection_mode_combo = QComboBox()
+        self.injection_mode_combo.addItems(["auto", "pynput", "ydotool", "adb"])
+        self.injection_mode_combo.setCurrentText(self.cfg.get("injection_mode", "auto"))
+        self.injection_mode_combo.currentTextChanged.connect(self._on_injection_mode_changed)
+        layout.addRow("Injection Mode", self.injection_mode_combo)
+
+        self.adb_serial_edit = QLineEdit(self.cfg.get("adb_serial") or "")
+        self.adb_serial_edit.setPlaceholderText("e.g. 127.0.0.1:5555 (docker-android / Waydroid adb)")
+        layout.addRow("ADB Serial", self.adb_serial_edit)
+
+        self.lbl_injection_hint = QLabel("")
+        self.lbl_injection_hint.setWordWrap(True)
+        layout.addRow("", self.lbl_injection_hint)
+
+        self._update_injection_hint()
+        return group
+
+    def _on_injection_mode_changed(self, _value: str):
+        self._update_injection_hint()
+
+    def _update_injection_hint(self):
+        mode = self.injection_mode_combo.currentText()
+        if mode == "adb":
+            self.adb_serial_edit.setEnabled(True)
+            self.lbl_injection_hint.setText(
+                "ADB targets Android-in-a-container (docker-android, Waydroid-with-adb) "
+                "directly, bypassing host key injection entirely. It sends a single tap per "
+                "PTT press, not press-and-hold — set Zello's PTT hotkey mode to TOGGLE, "
+                "not Hold. See README for docker-android setup."
+            )
+        elif mode == "ydotool":
+            self.adb_serial_edit.setEnabled(False)
+            self.lbl_injection_hint.setText(
+                "Forces ydotool key injection via /dev/uinput (Linux only). Useful on "
+                "Wayland where host key injection is normally blocked."
+            )
+        elif mode == "pynput":
+            self.adb_serial_edit.setEnabled(False)
+            self.lbl_injection_hint.setText(
+                "Forces standard host keyboard injection (X11/macOS/Windows). Will not "
+                "reach BlueStacks/Waydroid/docker-android reliably under Wayland."
+            )
+        else:
+            self.adb_serial_edit.setEnabled(True)
+            self.lbl_injection_hint.setText(
+                "Auto: keyboard injection normally, ydotool automatically on a detected "
+                "Wayland session. Choose 'adb' explicitly to target a Docker/emulator Android."
+            )
 
     def _build_audio_group(self):
         group = QGroupBox("Audio")
@@ -576,6 +659,8 @@ class MainWindow(QMainWindow):
         payload["dry_run"] = self.chk_dry_run.isChecked()
         payload["force_serial_ptt"] = self.chk_force_serial_ptt.isChecked()
         payload["ignore_initial_ptt_state"] = self.chk_ignore_initial_ptt.isChecked()
+        payload["injection_mode"] = self.injection_mode_combo.currentText()
+        payload["adb_serial"] = self.adb_serial_edit.text().strip() or None
 
         payload["vox"] = {
             "enabled": self.chk_vox_enabled.isChecked(),
@@ -631,6 +716,14 @@ class MainWindow(QMainWindow):
 
         if self.chk_force_serial_ptt.isChecked():
             args.append("--force-serial-ptt")
+
+        injection_mode = self.injection_mode_combo.currentText()
+        if injection_mode and injection_mode != "auto":
+            args.extend(["--injection-mode", injection_mode])
+
+        adb_serial = self.adb_serial_edit.text().strip()
+        if adb_serial:
+            args.extend(["--adb-serial", adb_serial])
 
         if self.audio_in_combo.currentData() is not None:
             args.extend(["--audio-input-index", str(self.audio_in_combo.currentData())])

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -102,6 +102,73 @@ def ydotool_key(code, down, dry=False):
         return False
 
 
+# Android KeyEvent keycodes (frameworks/base/core/java/android/view/KeyEvent.java), for
+# triggering PTT inside Android-in-a-container targets (docker-android/budtmo, HQarroum's
+# docker-android, and Waydroid) over ADB, where there is no host window for pynput/ydotool
+# to inject into at all.
+ANDROID_ADB_KEYCODES = {
+    "f1": 131, "f2": 132, "f3": 133, "f4": 134, "f5": 135, "f6": 136,
+    "f7": 137, "f8": 138, "f9": 139, "f10": 140, "f11": 141, "f12": 142,
+    "esc": 111, "escape": 111,
+    "space": 62,
+    "enter": 66, "return": 66,
+    "tab": 61,
+    "shift": 59, "ctrl": 113, "alt": 57, "cmd": 117, "win": 117,
+    "a": 29, "b": 30, "c": 31, "d": 32, "e": 33, "f": 34, "g": 35,
+    "h": 36, "i": 37, "j": 38, "k": 39, "l": 40, "m": 41, "n": 42,
+    "o": 43, "p": 44, "q": 45, "r": 46, "s": 47, "t": 48, "u": 49,
+    "v": 50, "w": 51, "x": 52, "y": 53, "z": 54,
+    "0": 7, "1": 8, "2": 9, "3": 10, "4": 11, "5": 12, "6": 13, "7": 14, "8": 15, "9": 16,
+}
+
+
+def adb_keycode(name):
+    if not name:
+        return None
+    return ANDROID_ADB_KEYCODES.get(str(name).strip().lower())
+
+
+def adb_available():
+    return shutil.which("adb") is not None
+
+
+def adb_ensure_connected(serial, dry=False):
+    if not serial:
+        return False
+    if dry:
+        logger.debug(f"[DRY] adb connect {serial}")
+        return True
+    try:
+        result = subprocess.run(
+            ["adb", "connect", serial], capture_output=True, text=True, timeout=5
+        )
+        output = (result.stdout or "") + (result.stderr or "")
+        ok = "connected to" in output.lower() or "already connected" in output.lower()
+        if not ok:
+            logger.error(f"adb connect {serial} failed: {output.strip()}")
+        return ok
+    except Exception as e:
+        logger.error(f"adb connect {serial} failed: {e}")
+        return False
+
+
+def adb_key_tap(serial, code, dry=False):
+    cmd = ["adb"]
+    if serial:
+        cmd += ["-s", serial]
+    cmd += ["shell", "input", "keyevent", str(code)]
+
+    if dry:
+        logger.debug(f"[DRY] {' '.join(cmd)}")
+        return True
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=5)
+        return True
+    except Exception as e:
+        logger.error(f"adb keyevent injection failed: {e}")
+        return False
+
+
 def parse_hotkey(name):
     if not name:
         return Key.f9
@@ -129,6 +196,16 @@ DEFAULT_CONFIG = {
     "disable_hotkey": True,
     "force_serial_ptt": True,
     "ignore_initial_ptt_state": True,
+
+    # injection_mode controls how the PTT hotkey reaches the Zello target:
+    #   auto    - pynput normally; ydotool automatically on a detected Wayland session
+    #   pynput  - always use host keyboard injection (X11/macOS/Windows)
+    #   ydotool - always use ydotool (Linux uinput injection)
+    #   adb     - send an ADB `input keyevent` tap into an Android target (docker-android,
+    #             Waydroid-with-adb, or any adb-reachable emulator/device). This is
+    #             edge-triggered, not press-and-hold: set Zello's PTT hotkey to TOGGLE mode.
+    "injection_mode": "auto",
+    "adb_serial": None,
 
     "cm108": {
         "vendor_id": 0x0D8C,
@@ -565,16 +642,33 @@ def build_radio_backend(cfg, args):
 
 
 class PTTController:
-    def __init__(self, backend, hotkey=None, hotkey_enabled=False, dry_run=False, ydotool_code=None):
+    def __init__(
+        self,
+        backend,
+        hotkey=None,
+        hotkey_enabled=False,
+        dry_run=False,
+        ydotool_code=None,
+        adb_code=None,
+        adb_serial=None,
+    ):
         self.backend = backend
         self.hotkey = hotkey
         self.hotkey_enabled = hotkey_enabled
         self.dry_run = dry_run
         self.ydotool_code = ydotool_code
+        self.adb_code = adb_code
+        self.adb_serial = adb_serial
         self.is_down = False
         self.lock = threading.Lock()
 
     def _inject_key(self, down):
+        if self.adb_code is not None:
+            # ADB `input keyevent` is a discrete tap, not press-and-hold: only fire on the
+            # down edge and rely on Zello's TOGGLE hotkey mode, not HOLD.
+            if down:
+                adb_key_tap(self.adb_serial, self.adb_code, dry=self.dry_run)
+            return
         if self.ydotool_code is not None:
             ydotool_key(self.ydotool_code, down, dry=self.dry_run)
         elif self.hotkey is not None:
@@ -591,7 +685,7 @@ class PTTController:
             logger.info(f"PTT DOWN ({source})")
 
             if self.hotkey_enabled:
-                logger.info("PTT DOWN -> key down")
+                logger.info("PTT DOWN -> adb toggle tap" if self.adb_code is not None else "PTT DOWN -> key down")
                 self._inject_key(True)
 
             self.backend.ptt_on(dry=self.dry_run)
@@ -604,7 +698,8 @@ class PTTController:
             logger.info(f"PTT UP ({source})")
 
             if self.hotkey_enabled:
-                logger.info("PTT UP -> key up")
+                if self.adb_code is None:
+                    logger.info("PTT UP -> key up")
                 self._inject_key(False)
 
             self.backend.ptt_off(dry=self.dry_run)
@@ -787,6 +882,19 @@ def main():
     parser.add_argument("--ptt-active-low", action="store_true")
     parser.add_argument("--ptt-active-high", action="store_true")
 
+    parser.add_argument(
+        "--injection-mode",
+        choices=["auto", "pynput", "ydotool", "adb"],
+        default=None,
+        help="How the hotkey reaches the Zello target. 'adb' targets Android-in-a-container "
+        "(docker-android, Waydroid-with-adb) over ADB and requires --adb-serial.",
+    )
+    parser.add_argument(
+        "--adb-serial",
+        default=None,
+        help="ADB target for --injection-mode adb, e.g. 127.0.0.1:5555",
+    )
+
     args = parser.parse_args()
 
     cfg = load_config(args.config)
@@ -821,11 +929,57 @@ def main():
     hotkey_obj = None
     use_ydotool = False
     ydotool_code = None
+    adb_code = None
+    adb_serial_value = None
 
     if hotkey_enabled:
+        injection_mode = str(args.injection_mode or cfg.get("injection_mode") or "auto").lower()
         is_wayland = platform.system() == "Linux" and os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
 
-        if is_wayland:
+        if injection_mode == "adb":
+            adb_serial_value = args.adb_serial or cfg.get("adb_serial")
+            if not adb_available():
+                logger.error(
+                    "injection_mode=adb but 'adb' was not found on PATH. "
+                    "Install Android platform-tools."
+                )
+                sys.exit(10)
+            if not adb_serial_value:
+                logger.error(
+                    "injection_mode=adb requires --adb-serial or config 'adb_serial' "
+                    "(e.g. 127.0.0.1:5555)."
+                )
+                sys.exit(10)
+            adb_code = adb_keycode(hotkey_name)
+            if adb_code is None:
+                logger.error(f"No ADB keycode mapping for hotkey '{hotkey_name}'.")
+                sys.exit(10)
+            if not adb_ensure_connected(adb_serial_value, dry=args.dry_run):
+                logger.error(
+                    f"Could not connect to ADB target {adb_serial_value}. Is the "
+                    "container/emulator running and its ADB port reachable?"
+                )
+                sys.exit(10)
+            logger.warning(
+                "ADB PTT injection is edge-triggered (a single tap), not press-and-hold. "
+                "Set Zello's PTT hotkey mode to TOGGLE (not Hold), or PTT will only ever "
+                "start and never stop."
+            )
+            logger.info(f"ADB PTT target: {adb_serial_value} ({hotkey_name} -> keycode {adb_code})")
+
+        elif injection_mode == "ydotool":
+            candidate_code = ydotool_keycode(hotkey_name)
+            if not ydotool_available() or candidate_code is None:
+                logger.error(
+                    "injection_mode=ydotool but ydotool is unavailable, or the hotkey has "
+                    "no ydotool keycode mapping."
+                )
+                sys.exit(10)
+            use_ydotool = True
+            ydotool_code = candidate_code
+            logger.info(f"Using ydotool for key injection ({hotkey_name} -> keycode {ydotool_code}).")
+
+        elif injection_mode == "auto" and is_wayland:
             candidate_code = ydotool_keycode(hotkey_name)
             if ydotool_available() and candidate_code is not None:
                 use_ydotool = True
@@ -841,12 +995,12 @@ def main():
                     "serial/CM108 PTT with --force-serial-ptt)."
                 )
 
-        if not use_ydotool:
+        if adb_code is None and not use_ydotool:
             if Controller is None:
                 logger.error(
                     "pynput is not available for keyboard injection.\n"
                     "Install pynput, pass --no-hotkey / --force-serial-ptt to rely on serial "
-                    "PTT only, or (on Wayland) install ydotool."
+                    "PTT only, or use --injection-mode ydotool/adb."
                 )
                 sys.exit(9)
             hotkey_obj = parse_hotkey(hotkey_name)
@@ -873,6 +1027,8 @@ def main():
         hotkey_enabled=hotkey_enabled,
         dry_run=args.dry_run,
         ydotool_code=ydotool_code,
+        adb_code=adb_code,
+        adb_serial=adb_serial_value,
     )
 
     if args.test_ptt:


### PR DESCRIPTION
## Summary

Adds support for triggering PTT inside Android-in-a-container targets — [budtmo/docker-android](https://github.com/budtmo/docker-android) and [HQarroum/docker-android](https://github.com/HQarroum/docker-android) — plus documents how ZPTTLink maps onto every Android runtime it can target (BlueStacks, Waydroid, and both docker-android projects).

**Why ADB, and why it's a tap, not a hold:** neither docker-android project exposes a host window for pynput/ydotool to inject a key into — the only interface out is ADB. Android's `adb shell input keyevent` dispatches a press+release together as one atomic event; there's no way to hold a key down over ADB the way DTR/RTS or a real keyboard can. So `injection_mode: adb` sends exactly one tap on the PTT-down edge and does nothing on PTT-up — this requires setting **Zello's PTT hotkey mode to Toggle, not Hold**. This tradeoff was discussed and chosen explicitly over two alternatives (repeated-tap hold simulation, or not building triggering at all).

**Also surfaced, not fixed:** neither docker-android image passes audio through to the host by default (HQarroum's runs with `-no-audio`; budtmo's doesn't document audio at all). That's a container/QEMU-audio-flags problem outside ZPTTLink's control — documented as a known limitation with a pointer to the general approach (PulseAudio-over-network into the container), rather than a copy-paste recipe I can't verify without the actual image running.

## Changes

- `injection_mode: "adb"` (alongside existing `pynput`/`ydotool`), config + `--injection-mode`/`--adb-serial` CLI flags, default `"auto"` (no behavior change for existing configs)
- Android `KeyEvent` keycode map (`ANDROID_ADB_KEYCODES`) — distinct keycode space from the existing Linux-evdev `YDOTOOL_KEYCODES` map
- GUI: new "Android Target" panel — injection-mode combo, ADB serial field, mode-specific hint text; best-effort `docker ps` detection of a running docker-android container for the status panel
- README: new "Android Runtime Targets" section (BlueStacks / Waydroid / both docker-android projects, with concrete `docker run` + config examples) and a "Known Limitations" section stating the TX-only and ADB-toggle constraints explicitly; also fixes stale dependency lists left over from earlier releases (`pyalsa` removal, missing `pyusb`/`PySide6`)

## Test plan

- [x] `py_compile` on all touched files
- [x] Headless GUI construction (`QT_QPA_PLATFORM=offscreen`); exercised the injection-mode combo, hint text, config payload, and generated CLI args
- [x] `--injection-mode adb` without `adb` on PATH fails cleanly with a clear error (exit 10)
- [x] With a stub `adb` script on PATH: dry-run makes **zero** subprocess calls; non-dry-run issues exactly `adb connect <serial>` once, then one `adb -s <serial> shell input keyevent <code>` per PTT-down and correctly **nothing** on PTT-up (confirmed via a call log written by the stub)
- [x] Regression-checked explicit `injection_mode: pynput` and the existing auto/Wayland/ydotool path still work unchanged
- [ ] Not tested against a real docker-android container, real ADB target, or real Android device — no Docker/emulator available in this environment. Would appreciate a real-world test before merging if you have a docker-android instance handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)