### PR TITLE
Harden for unattended Raspberry Pi deployment + repeater-site tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@
 
 <h2>Installation and Setup</h2>
 
+<p><strong>Deploying to an unattended Raspberry Pi</strong> (e.g. boxed up at a repeater site)? See the dedicated <a href="docs/raspberry-pi-repeater-deployment.md">Raspberry Pi deployment tutorial</a> — hardware, headless OS setup, Waydroid + Zello, systemd autostart with a watchdog, and outdoor/unattended hardening. The steps below are the general/manual install; the Pi tutorial builds on them.</p>
+
 <ol>
   <li>Install Python:
     <ul>

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,44 @@
+
+# Systemd units for unattended Raspberry Pi deployment
+
+These are **user** systemd units (not system units) so they run under your normal
+user's session — the one with access to PipeWire/PulseAudio and, if applicable,
+the Waydroid/ADB environment — without needing root or fighting `XDG_RUNTIME_DIR`
+permission issues that come with running audio apps as a system service.
+
+Full walkthrough: [`docs/raspberry-pi-repeater-deployment.md`](../../docs/raspberry-pi-repeater-deployment.md).
+
+## Install
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp zpttlink.service ~/.config/systemd/user/
+# Only if Zello runs inside Waydroid on this same Pi:
+cp zpttlink-android.service ~/.config/systemd/user/
+
+# Let user services start at boot without an interactive login (essential for a
+# headless box):
+sudo loginctl enable-linger "$USER"
+
+systemctl --user daemon-reload
+systemctl --user enable --now zpttlink.service
+# If using the Waydroid companion unit:
+systemctl --user enable --now zpttlink-android.service
+```
+
+## Operating
+
+```bash
+systemctl --user status zpttlink.service
+journalctl --user -u zpttlink.service -f
+systemctl --user restart zpttlink.service
+```
+
+## Why `Type=notify` + `WatchdogSec`
+
+`Restart=on-failure` alone only recovers a process that actually *exits*. If the
+audio thread wedges without crashing the process, a plain restart policy never
+fires. ZPTTLink sends a `WATCHDOG=1` heartbeat every 10 seconds while its audio
+stream is healthy; `WatchdogSec=30` gives it three missed heartbeats of slack
+before systemd concludes it's hung and force-restarts it — the failure mode that
+matters most for a box nobody is going to walk out to and power-cycle.

--- a/deploy/systemd/zpttlink-android.service
+++ b/deploy/systemd/zpttlink-android.service
@@ -1,0 +1,20 @@
+
+[Unit]
+Description=Start Waydroid session and launch Zello for ZPTTLink
+Documentation=https://github.com/maxhayim/ZPTTLink
+After=graphical-session.target waydroid-container.service
+Wants=waydroid-container.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/waydroid session start
+# Give the Waydroid session a moment to come up before launching Zello into it.
+ExecStartPost=/bin/sleep 5
+ExecStartPost=/usr/bin/waydroid app launch com.zello.client
+ExecStop=/usr/bin/waydroid session stop
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/zpttlink.service
+++ b/deploy/systemd/zpttlink.service
@@ -1,0 +1,32 @@
+
+[Unit]
+Description=ZPTTLink Zello <-> Radio PTT Gateway
+Documentation=https://github.com/maxhayim/ZPTTLink
+After=network-online.target sound.target
+Wants=network-online.target
+# If Zello runs inside Waydroid on this same box and you're using the companion
+# zpttlink-android.service to start it, uncomment these so ZPTTLink waits for it:
+#After=zpttlink-android.service
+#Wants=zpttlink-android.service
+
+[Service]
+Type=notify
+# ZPTTLink sends sd_notify(READY=1) once the audio stream is up, and a WATCHDOG=1
+# heartbeat every 10s while it stays healthy. If those heartbeats stop for
+# WatchdogSec (audio thread hung, not just crashed) systemd force-restarts it -
+# something a plain Restart=on-failure cannot catch on its own.
+WatchdogSec=30
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=300
+StartLimitBurst=20
+# Comfortably above ZPTTLink's own --serial-wait-timeout (default 30s) plus audio
+# stream startup. Raise this if you raise serial_wait_timeout in config.json.
+TimeoutStartSec=60
+
+WorkingDirectory=%h/ZPTTLink
+Environment=PYTHONUNBUFFERED=1
+ExecStart=%h/ZPTTLink/venv/bin/python -m zpttlink --config %h/ZPTTLink/config.json
+
+[Install]
+WantedBy=default.target

--- a/docs/raspberry-pi-repeater-deployment.md
+++ b/docs/raspberry-pi-repeater-deployment.md
@@ -1,0 +1,248 @@
+# Deploying ZPTTLink on a Raspberry Pi at a repeater site
+
+This walks through building an unattended ZPTTLink box: a Raspberry Pi, a radio
+interface, and a copy of Zello, sealed in an enclosure and left running next to
+a repeater with nobody around to babysit it. It assumes you've read the main
+[README](../README.md), especially [Android Runtime
+Targets](../README.md#android-runtime-targets) and [Known
+Limitations](../README.md#known-limitations).
+
+**Read this first if that's your plan:** ZPTTLink today is a **TX-only** bridge
+— it sends Zello/mic audio to the radio and keys the radio to match, but it does
+not yet route received radio audio back into Zello. If your goal is a full
+duplex Zello↔repeater gateway (talk on Zello, hear the repeater, and vice
+versa), that RX path doesn't exist yet — build and test the TX path first, and
+track the RX gap before you seal the box and drive away.
+
+## 1. What you're building
+
+```
+        Zello network
+              │
+      ┌───────▼────────┐
+      │  Waydroid (or   │   Zello audio + PTT hotkey
+      │  docker-android)│──────────────┐
+      └────────────────┘               │
+              ▲                        ▼
+              │ ADB (optional)   ┌─────────────┐
+              └──────────────────│  ZPTTLink   │
+                                  │ (this repo) │
+                                  └──────┬──────┘
+                                         │ USB serial (DTR/RTS) or HID (CM108)
+                                         ▼
+                                  ┌─────────────┐
+                                  │  AIOC/CM108 │
+                                  │  interface  │
+                                  └──────┬──────┘
+                                         ▼
+                                  Radio ↔ Repeater
+```
+
+Everything above the USB interface runs on one Raspberry Pi.
+
+## 2. Hardware
+
+- **Raspberry Pi 4 or 5, 4GB+ RAM.** Waydroid needs a real 64-bit kernel and
+  enough RAM to run an Android userspace comfortably alongside ZPTTLink's audio
+  thread; don't try this on a Pi Zero/3.
+- **Boot from USB SSD if the Pi model supports it**, not a microSD card. This
+  is the single biggest reliability upgrade you can make for a box that will
+  never get a graceful shutdown — SD cards corrupt far more easily under power
+  loss than a proper SSD, and this box *will* lose power eventually.
+- **AIOC, CM108/CM119-based, or DigiRig USB interface** cabled to your radio.
+- **A quality 5V/3A (or PD) power supply**, and ideally a small UPS (a PiJuice
+  HAT or similar supercap/battery UPS) so a brief power blip doesn't corrupt
+  the filesystem mid-write. At minimum, this is cheap insurance against the
+  exact failure mode ("nobody's there to power-cycle it") this whole tutorial
+  is trying to prevent.
+- **A vented, weatherproof enclosure.** Sealed plastic boxes in direct sun
+  turn into ovens; the Pi will thermal-throttle (or shut down) well before it's
+  actually damaged, but throttling under load can still disrupt audio timing.
+  Use a light-colored, ventilated (but weather-sealed against driven rain)
+  enclosure, and add a heatsink/fan if it'll see summer sun.
+
+### RF interference
+
+You're putting a Pi, USB cables, and (if you're using Ethernet) an unshielded
+cable run right next to a transmitter. Real-world RFI symptoms here look like
+garbled audio, a Pi that randomly reboots when the repeater keys up, or a USB
+serial port that drops out under transmit. Mitigate with:
+
+- Ferrite chokes on the USB cable(s) and any Ethernet/power runs near the feed line
+- Keeping the Pi and its PSU physically separated from the antenna feedline/duplexer, not zip-tied to it
+- Proper station grounding — the Pi's enclosure and the radio should share a solid ground reference, not float independently
+- Shielded USB cables over unshielded ones, especially for longer runs
+
+## 3. Flash the OS headless
+
+Use Raspberry Pi Imager. In the gear icon / advanced options **before
+flashing**, set:
+
+- Hostname (e.g. `zpttlink-siteA`)
+- Enable SSH, **key-based auth** (skip password auth entirely if you can — this
+  box has no keyboard to type a password recovery on anyway)
+- WiFi SSID/password (prefer Ethernet if the site has it — it's far more
+  reliable than WiFi for something you can't walk over and reset)
+- Locale/timezone, so your logs have sane timestamps
+
+Boot it, then `ssh pi@zpttlink-siteA.local` (mDNS/avahi is enabled by default
+on Raspberry Pi OS).
+
+## 4. System prep
+
+```bash
+sudo apt update && sudo apt full-upgrade -y
+sudo apt install -y python3 python3-venv python3-pip git \
+  libasound2-dev build-essential
+
+# Serial + audio group access for the 'pi' user (or whatever user you're using)
+sudo usermod -aG dialout,audio,plugdev "$USER"
+# Log out/in (or reboot) for the group change to take effect
+```
+
+## 5. Install Waydroid and Zello
+
+```bash
+curl https://repo.waydro.id | sudo bash
+sudo apt install -y waydroid
+sudo waydroid init
+```
+
+Start a session and get Zello installed once, interactively, over VNC (enable
+it via `sudo raspi-config` → Interface Options → VNC, then connect with any VNC
+client) — this is the easiest way to see Waydroid's screen the first time:
+
+```bash
+waydroid session start
+```
+
+Sideload the Zello APK (`adb install /path/to/zello.apk`, after `adb connect
+127.0.0.1:5555` — Waydroid exposes ADB once enabled, see Waydroid's own docs
+for `adb_enabled`), log into your Zello account, and set Zello's PTT hotkey to
+match your ZPTTLink config (default `F9`). Do this once with a display attached
+or over VNC; you won't need a display again after this.
+
+## 6. Install ZPTTLink
+
+```bash
+git clone https://github.com/maxhayim/ZPTTLink.git ~/ZPTTLink
+cd ~/ZPTTLink
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Find your devices:
+
+```bash
+python -m zpttlink --list-serial
+python -m zpttlink --list-audio
+```
+
+If `--list-audio` comes back empty, see the [PipeWire/ALSA
+troubleshooting](../README.md#linux-notes) note in the README before going
+further — this is a common Pi-specific failure mode and there's a documented
+fix path for it.
+
+Write `~/ZPTTLink/config.json` (or run the GUI once over VNC/X-forwarding
+with `python -m zpttlink --gui` and hit Save Config — same result):
+
+```json
+{
+  "radio_type": "auto",
+  "com_port": "/dev/ttyACM0",
+  "serial_wait_timeout": 30,
+
+  "audio_input_index": 1,
+  "audio_output_index": 2,
+
+  "ptt_hotkey": "F9",
+  "ptt_output": "dtr",
+  "force_serial_ptt": true,
+  "ignore_initial_ptt_state": true,
+
+  "vox": { "enabled": true, "threshold": 0.01 }
+}
+```
+
+`force_serial_ptt: true` means ZPTTLink keys the radio directly via DTR/RTS —
+deterministic, and it doesn't depend on Zello's hotkey reaching Waydroid at
+all. If you'd rather also trigger Zello's own hotkey so its UI reflects TX
+state, set `force_serial_ptt: false` and either `injection_mode: adb` (see
+[Android Runtime Targets](../README.md#android-runtime-targets) — remember
+Zello's hotkey mode needs to be **Toggle**, not Hold, for ADB) or leave it on
+`auto` for host key injection.
+
+Confirm hardware PTT works before wiring in Zello at all:
+
+```bash
+python -m zpttlink --test-ptt --serial /dev/ttyACM0
+```
+
+## 7. Install as a systemd user service
+
+Ready-made unit files are in [`deploy/systemd/`](../deploy/systemd/README.md).
+Short version:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp ~/ZPTTLink/deploy/systemd/zpttlink.service ~/.config/systemd/user/
+cp ~/ZPTTLink/deploy/systemd/zpttlink-android.service ~/.config/systemd/user/
+
+sudo loginctl enable-linger "$USER"   # start user services at boot, no login needed
+systemctl --user daemon-reload
+systemctl --user enable --now zpttlink-android.service
+systemctl --user enable --now zpttlink.service
+```
+
+Watch it come up:
+
+```bash
+journalctl --user -u zpttlink.service -f
+```
+
+You should see the serial/CM108 device get picked up, the audio stream start,
+and `PTT system ready`. Key the radio (or make some noise into the mic, if
+VOX is enabled) and confirm you see `PTT DOWN` / `PTT UP` and the radio
+actually transmits.
+
+Reboot the whole Pi once here (`sudo reboot`) and confirm everything comes
+back up on its own — that's the real test, not just `systemctl start`.
+
+## 8. Unattended hardening
+
+- **Power loss:** if you skipped the UPS, at minimum use a filesystem that
+  tolerates unclean shutdowns reasonably (ext4's default journaling helps, but
+  isn't a substitute for real power protection). A USB SSD boot drive (step 2)
+  matters more here than almost anything else on this list.
+- **SD/SSD wear:** ZPTTLink's own logging is modest (512KB × 2 rotated files),
+  but combined with normal OS logging over months of 24/7 runtime, consider
+  `journalctl`'s own rotation limits (`SystemMaxUse=` in
+  `/etc/systemd/journald.conf`) so logs don't grow unbounded.
+- **Network:** prefer wired Ethernet. If you're on WiFi/cellular at a remote
+  site, consider a simple watchdog cron job that reboots the Pi if it can't
+  reach the internet for N minutes — a box that silently drops off the network
+  and never recovers is just as bad as one that crashes.
+- **Remote access without port-forwarding:** most repeater sites aren't going
+  to give you a public IP to port-forward into. Consider
+  [Tailscale](https://tailscale.com/) or ZeroTier so you can `ssh` in from
+  anywhere without exposing the box directly to the internet.
+- **Updates:** weigh `unattended-upgrades` (security patches, unattended)
+  against the risk of an update landing badly on a box nobody can walk over to
+  fix. A common middle ground: apply updates manually during a scheduled
+  maintenance visit, not automatically.
+- **The systemd watchdog is your friend here.** `zpttlink.service` uses
+  `Type=notify` + `WatchdogSec=30` — if the audio thread wedges (not crashes,
+  *wedges*) without you there, systemd notices the missing heartbeat and
+  restarts it on its own. See [`deploy/systemd/README.md`](../deploy/systemd/README.md)
+  for why this matters more than a plain restart policy.
+
+## 9. Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `--list-audio` empty | See [Linux Notes](../README.md#linux-notes) — usually a missing PipeWire/Pulse compatibility layer |
+| Radio keys immediately on start | Confirm `ignore_initial_ptt_state: true`; check `journalctl` for "Ignoring initial PTT state" on startup |
+| Service won't come up after reboot | `journalctl --user -u zpttlink.service -b` — likely the USB device enumerated later than `serial_wait_timeout`; raise it in config.json (and `TimeoutStartSec` in the unit if you raise it a lot) |
+| Zello never transmits, but `PTT DOWN` logs fine | You're likely on `injection_mode: adb` without Zello's hotkey set to **Toggle** — see [Android Runtime Targets](../README.md#android-runtime-targets) |
+| Random reboots when the repeater keys up | RFI — see the hardware section above; try ferrite chokes and re-check grounding before suspecting the Pi itself |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="zpttlink",
     version="2.1.0",
-    description="Bridge Zello to radio hardware using AIOC and Python",
+    description="Zello <-> radio PTT gateway with deterministic DTR/RTS/CM108 PTT and pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android",
     author="Max Hayim",
     packages=find_packages(),
     install_requires=[

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -5,6 +5,7 @@ import os
 import platform
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -207,6 +208,11 @@ DEFAULT_CONFIG = {
     "injection_mode": "auto",
     "adb_serial": None,
 
+    # Seconds to wait for the radio's USB serial/HID device to enumerate before giving up.
+    # Matters on headless boot (e.g. a Pi powering on alongside its USB radio interface),
+    # where udev can lag a systemd service start by a few seconds. 0 disables waiting.
+    "serial_wait_timeout": 30,
+
     "cm108": {
         "vendor_id": 0x0D8C,
         "product_id": None,
@@ -325,6 +331,28 @@ def autodetect_serial(match_substrings):
         ranked.append((score, p.device))
     ranked.sort(reverse=True)
     return ranked[0][1] if ranked else None
+
+
+def wait_until(check_fn, timeout, poll_interval=1.0, waiting_message=None):
+    """Poll check_fn() until it returns a truthy value or timeout elapses.
+
+    On a headless boot (e.g. a Pi powering up alongside its USB radio interface),
+    the interface's udev/USB enumeration can lag the service start by a few
+    seconds. Retrying here avoids a hard failure -> full systemd restart cycle
+    for what is normally just a brief startup race.
+    """
+    deadline = time.monotonic() + timeout if timeout > 0 else time.monotonic()
+    logged = False
+    while True:
+        result = check_fn()
+        if result:
+            return result
+        if time.monotonic() >= deadline:
+            return result
+        if waiting_message and not logged:
+            logger.info(waiting_message)
+            logged = True
+        time.sleep(poll_interval)
 
 
 def _audio_role_label(dev):
@@ -590,13 +618,47 @@ def build_radio_backend(cfg, args):
     ignore_initial_state = bool(
         getattr(args, "ignore_initial_ptt_state", False) or cfg.get("ignore_initial_ptt_state", True)
     )
+    serial_wait_timeout = float(
+        args.serial_wait_timeout
+        if getattr(args, "serial_wait_timeout", None) is not None
+        else cfg.get("serial_wait_timeout", 30)
+    )
 
     if radio_type == "cm108":
+        if usb is None:
+            logger.error("pyusb not installed. Install with: pip install pyusb")
+            sys.exit(2)
+
         cm_cfg = cfg.get("cm108", {})
         vendor_id = int(cm_cfg.get("vendor_id", 0x0D8C))
         product_id = cm_cfg.get("product_id", None)
         gpio_mask = int(cm_cfg.get("gpio_mask", 0x04))
         active_low = bool(cm_cfg.get("active_low", False))
+
+        def _find_cm108():
+            kwargs = {"idVendor": vendor_id}
+            if product_id is not None:
+                kwargs["idProduct"] = product_id
+            try:
+                return usb.core.find(**kwargs) is not None
+            except Exception:
+                return False
+
+        found = wait_until(
+            _find_cm108,
+            serial_wait_timeout,
+            waiting_message=(
+                f"Waiting up to {serial_wait_timeout:.0f}s for CM108/CM119 device "
+                f"(vendor=0x{vendor_id:04x}) to enumerate..."
+            ),
+        )
+        if not found:
+            logger.error(
+                f"CM108/CM119 device not found (vendor=0x{vendor_id:04x}) after "
+                f"waiting {serial_wait_timeout:.0f}s."
+            )
+            sys.exit(2)
+
         return CM108Radio(
             vendor_id=vendor_id,
             product_id=product_id,
@@ -623,11 +685,36 @@ def build_radio_backend(cfg, args):
 
     serial_port = args.serial or cfg.get("com_port") or ""
     if not serial_port:
-        serial_port = autodetect_serial(cfg.get("serial_autodetect_hints", []))
-        if serial_port:
+        detected = wait_until(
+            lambda: autodetect_serial(cfg.get("serial_autodetect_hints", [])),
+            serial_wait_timeout,
+            waiting_message=(
+                f"No serial device detected yet; waiting up to {serial_wait_timeout:.0f}s "
+                "for one to appear..."
+            ),
+        )
+        if detected:
+            serial_port = detected
             logger.info(f"Auto-detected serial port: {serial_port}")
         else:
-            logger.error("No serial port specified and auto-detect found none.")
+            logger.error(
+                f"No serial port specified and auto-detect found none after waiting "
+                f"{serial_wait_timeout:.0f}s."
+            )
+            sys.exit(2)
+    elif serial_port.startswith(("/dev/", "/tmp/")):
+        exists = wait_until(
+            lambda: os.path.exists(serial_port),
+            serial_wait_timeout,
+            waiting_message=(
+                f"Waiting up to {serial_wait_timeout:.0f}s for serial device "
+                f"{serial_port} to appear..."
+            ),
+        )
+        if not exists:
+            logger.error(
+                f"Serial device {serial_port} did not appear within {serial_wait_timeout:.0f}s."
+            )
             sys.exit(2)
 
     baud = args.baud if args.baud is not None else int(cfg.get("baud", 9600))
@@ -826,6 +913,31 @@ def handle_stop_signal(*_):
     stop_event.set()
 
 
+def sd_notify(message):
+    """Best-effort systemd readiness/watchdog notification (sd_notify(3) protocol).
+
+    No-ops entirely when not running under systemd (NOTIFY_SOCKET unset) and adds no
+    dependency — this is a plain AF_UNIX datagram, not the `sdnotify` PyPI package.
+    Used so `Type=notify` + `WatchdogSec=` in the systemd unit can detect a *hung*
+    process (audio thread deadlocked, no watchdog pings) and restart it, which a plain
+    `Restart=on-failure` cannot: that only fires on the process actually exiting.
+    """
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    if addr.startswith("@"):
+        addr = "\0" + addr[1:]
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            sock.connect(addr)
+            sock.sendall(message.encode())
+        finally:
+            sock.close()
+    except Exception:
+        pass
+
+
 def choose_samplerate(input_index, output_index, default_sr=48000):
     if not sd:
         return default_sr
@@ -858,6 +970,13 @@ def main():
     parser.add_argument("--config", default=DEFAULT_CONFIG_FILE)
     parser.add_argument("--key", help="Hotkey to send to Zello")
     parser.add_argument("--serial", help="Serial port override")
+    parser.add_argument(
+        "--serial-wait-timeout",
+        type=float,
+        default=None,
+        help="Seconds to wait for the radio's USB device to enumerate before giving up "
+        "(default 30; helps on headless boot where udev lags service start). 0 disables waiting.",
+    )
     parser.add_argument("--baud", type=int, default=None)
     parser.add_argument("--radio-type", choices=["auto", "cm108", "digirig", "signalink"], default=None)
     parser.add_argument("--ptt-output", choices=["none", "dtr", "rts"], default=None)
@@ -1166,11 +1285,31 @@ def main():
         f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, dry_run={args.dry_run})"
     )
     logger.info("ZPTTLink 2.1 TX bridge is running successfully! (Ctrl+C to exit)")
+    sd_notify("READY=1")
+
+    exit_code = 0
+    watchdog_interval = 10.0
+    last_watchdog = time.monotonic()
 
     try:
         while not stop_event.is_set():
-            time.sleep(0.1)
+            time.sleep(0.5)
+
+            if audio_stream is not None and not audio_stream.active:
+                logger.error(
+                    "Audio stream is no longer active (device disconnected or errored); "
+                    "exiting so the service manager can restart."
+                )
+                exit_code = 13
+                break
+
+            now = time.monotonic()
+            if now - last_watchdog >= watchdog_interval:
+                sd_notify("WATCHDOG=1")
+                last_watchdog = now
     finally:
+        sd_notify("STOPPING=1")
+
         try:
             ptt.up(source="shutdown")
         except Exception:
@@ -1189,6 +1328,9 @@ def main():
             pass
 
         logger.info("ZPTTLink stopped. Goodbye.")
+
+    if exit_code:
+        sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/zpttlink/pyproject.toml
+++ b/zpttlink/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "zpttlink"
 # We read the version from the package to keep it in one place
 dynamic = ["version", "readme"]
-description = "Bridge PTT cables to Zello (BlueStacks/Waydroid) with simple serial->hotkey logic."
+description = "Zello <-> radio PTT gateway with deterministic DTR/RTS/CM108 PTT and pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android"
 authors = [{ name = "Max Hayim" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -31,7 +31,7 @@ macos = ["pyobjc>=9.2; sys_platform == 'darwin'"]
 linux = ["pulsectl>=23.5.2; sys_platform == 'linux'"]
 
 # PyPI metadata
-keywords = ["zello", "ptt", "hamradio", "gmrs", "audio", "serial", "bluestacks", "waydroid"]
+keywords = ["zello", "ptt", "hamradio", "gmrs", "audio", "serial", "bluestacks", "waydroid", "docker-android", "adb", "raspberry-pi"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary

Prompted by the plan to run ZPTTLink unattended on Pis sealed in boxes at repeater sites. Two reliability gaps mattered specifically for that scenario, plus the tutorial itself:

**1. Boot-time USB race.** systemd starting the service before udev finishes enumerating the AIOC/CM108 interface previously meant an immediate, permanent failure. `build_radio_backend()` now waits (default 30s, `serial_wait_timeout` / `--serial-wait-timeout`, 0 to disable) for the device to appear instead of failing on the first check.

**2. Hung-but-not-crashed audio thread.** `Restart=on-failure` alone only recovers a process that actually exits — it does nothing for a wedged audio thread. Added a dependency-free `sd_notify()` (raw AF_UNIX datagram, not the `sdnotify` PyPI package) that sends `READY=1` on stream start and a `WATCHDOG=1` heartbeat every 10s; paired with `WatchdogSec=30` in the new systemd unit, a missed heartbeat now gets systemd to force-restart it. The main loop also directly checks `audio_stream.active` and exits(13) if it dies, vs. exit 0 on a clean SIGTERM — so systemd's restart policy does the right thing in both cases.

**3. Descriptions were stale again.** GitHub repo description, `setup.py`, and `pyproject.toml` still only mentioned BlueStacks/Waydroid, predating the DTR/RTS/CM108 PTT and docker-android/ADB work. Fixed all three (done directly against GitHub/repo, not part of this diff, plus the two packaging files that are).

**4. New tutorial:** `docs/raspberry-pi-repeater-deployment.md` — hardware selection (SSD-boot over SD, UPS, enclosure/thermal, RFI mitigation near a transmitter), headless OS setup, Waydroid+Zello, ZPTTLink config, systemd autostart (`deploy/systemd/`), and unattended-operation hardening. It states the TX-only limitation up front, in bold, before anyone gets far enough to be surprised by it in the field.

## Test plan

- [x] `py_compile` on all touched files; `pyproject.toml` parsed with `tomllib`
- [x] `wait_until()`: immediate-success case (existing device, no wait logged) and real-timeout case (`--serial-wait-timeout 3` against a nonexistent device: waits ~3s, clean exit 2); `--serial-wait-timeout 0` disables waiting and fails immediately
- [x] CM108 path fails fast and cleanly when `pyusb` is absent, before entering any wait loop
- [x] `sd_notify()` verified against a real `AF_UNIX` datagram listener (no-ops cleanly with `NOTIFY_SOCKET` unset; sends exactly the right bytes when set)
- [x] Full end-to-end daemon run with a real audio stream + `NOTIFY_SOCKET` listener: `READY=1` on stream start, `WATCHDOG=1` every ~10s while healthy, `SIGTERM` → `STOPPING=1` → clean exit (process gone, no zombie)
- [ ] Not tested: the exit(13)-on-dead-stream path itself (couldn't force a real PortAudio device failure in this environment), and nothing here has been tested on actual Raspberry Pi hardware or a real repeater site — everything above ran on macOS against real local audio/serial devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)