### PR TITLE
v3.0: Add Asterisk (USRP) backend — network radio-side option, real duplex audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>A full Zello ↔ radio gateway with deterministic PTT control</strong>
+  <strong>An open-source, all-in-one Zello ↔ radio ↔ Asterisk linking bridge with deterministic PTT control</strong>
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 
 <h1>ZPTTLink</h1>
 
-<p>ZPTTLink is an open-source, cross-platform application that bridges Zello with radio gateway hardware like the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>. It enables seamless Push-to-Talk (PTT) control and audio routing, allowing users to link RF radios to Zello using only a computer. Zello itself can run inside <a href="https://www.bluestacks.com/">BlueStacks</a> (macOS), <a href="https://waydro.id/">Waydroid</a> (Linux), or a dockerized Android emulator such as <a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a> or <a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a> — see <a href="#android-runtime-targets">Android Runtime Targets</a> below for how PTT reaches each one.</p>
+<p>ZPTTLink is an open-source, cross-platform application that bridges Zello with a radio-side target of your choice: physical radio gateway hardware like the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>, <strong>or</strong> a local/remote <a href="https://www.asterisk.org/">Asterisk</a> instance over the network (no radio hardware required for that leg — see <a href="#asterisk-usrp-backend">Asterisk (USRP) Backend</a>). Both are just different <code>radio_type</code> backends; nothing about the Zello side changes. It enables seamless Push-to-Talk (PTT) control and audio routing, allowing users to link RF radios (or an Asterisk node) to Zello using only a computer. Zello itself can run inside <a href="https://www.bluestacks.com/">BlueStacks</a> (macOS), <a href="https://waydro.id/">Waydroid</a> (Linux), or a dockerized Android emulator such as <a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a> or <a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a> — see <a href="#android-runtime-targets">Android Runtime Targets</a> below for how PTT reaches each one.</p>
 
 <p>This tool is ideal for GMRS and ham radio operators, emergency communications volunteers, and hobbyists who want to build a software-based radio gateway.</p>
 
@@ -267,6 +267,42 @@ adb install /path/to/zello.apk</code></pre>
 
 <p><strong>Audio is not bridged for either docker-android project.</strong> Both run headless by default — HQarroum's image explicitly starts the emulator with <code>-no-audio</code>, and budtmo's does not document any audio passthrough at all. That means ZPTTLink's audio bridge (mic-in → radio-out) has nothing to connect to inside a stock container: there is no virtual sound device reachable from the host. Getting audio into the emulator requires routing PulseAudio over the network into the container yourself — for example, enabling <code>module-native-protocol-tcp</code> on the host's PulseAudio server and pointing the emulator's own <code>-audio-backend</code>/<code>EXTRA_FLAGS</code> at it (see each project's <code>EXTRA_FLAGS</code> environment variable). Exact flags depend on the emulator/QEMU version bundled in the image, so treat this as a starting point, not a copy-paste recipe — consult the specific image's own issues/docs for the audio flags it currently supports. Until that's wired up, these two targets are useful for <strong>testing the ADB PTT trigger path</strong> with Zello's Toggle mode, not for a working end-to-end audio bridge.</p>
 
+<h2>Asterisk (USRP) Backend</h2>
+
+<p>Set <code>radio_type: "asterisk"</code> and ZPTTLink connects to a local or remote <a href="https://www.asterisk.org/">Asterisk</a> instance over the network instead of a physical radio interface — using the <strong>USRP protocol</strong>, the UDP audio+PTT wire format Asterisk's <code>app_rpt</code> module (<code>chan_usrp</code>) uses to let an external program act as a "radio" node without being a compiled Asterisk channel driver. No AIOC/CM108/DigiRig hardware is needed for this backend at all.</p>
+
+<p>This is <strong>additive, not a replacement</strong> — the existing hardware backends are unchanged. ZPTTLink now supports two independent kinds of "radio side": physical hardware, or Asterisk over the network. Pick whichever matches your setup with <code>--radio-type</code>.</p>
+
+<p>It runs equally well <strong>co-located on the same Pi/computer as Asterisk</strong> (point it at <code>127.0.0.1</code>) or <strong>on a separate box</strong> talking to a remote Asterisk instance over LAN/VPN — both are the exact same code path, just a different <code>asterisk.host</code>.</p>
+
+<h3>Configuration</h3>
+
+<pre><code>{
+  "radio_type": "asterisk",
+  "force_serial_ptt": false,
+  "disable_hotkey": false,
+  "injection_mode": "auto",
+
+  "asterisk": {
+    "host": "127.0.0.1",
+    "port": 32001,
+    "local_port": 0
+  }
+}</code></pre>
+
+<p>Or via the CLI: <code>python -m zpttlink --radio-type asterisk --asterisk-host 127.0.0.1 --asterisk-port 32001</code>. In the GUI, pick "asterisk" from the <strong>Radio Backend</strong> dropdown in the Connection panel.</p>
+
+<p><strong>Important:</strong> unlike the hardware backends (which default to <code>force_serial_ptt: true</code>, disabling hotkey injection since a serial/GPIO line keys the radio directly), the Asterisk backend has no hardware to key — it <em>needs</em> hotkey injection enabled with a working <code>injection_mode</code> so that audio arriving from Asterisk actually gets relayed into Zello's network. Leaving <code>force_serial_ptt: true</code> with <code>radio_type: asterisk</code> logs a warning at startup and effectively means Asterisk-side audio reaches Zello's mic input but Zello never transmits it.</p>
+
+<h3>How audio flows</h3>
+
+<p>This is the one backend where full duplex is real:</p>
+
+<ul>
+  <li><strong>Zello → Asterisk:</strong> Zello's outgoing audio (<code>audio_input_index</code>) is resampled to 8kHz/16-bit mono and sent as USRP voice frames. A local VOX gate decides the outbound <code>keyup</code> flag frame-by-frame.</li>
+  <li><strong>Asterisk → Zello:</strong> incoming USRP voice frames are resampled up to the device rate and written into <code>audio_output_index</code> (point this at whatever virtual audio device feeds Zello's <em>microphone</em> input — the reverse role <code>audio_output_index</code> plays for the hardware backends, where it feeds the radio's TX audio input instead). The incoming frame's <code>keyup</code> field drives <code>ptt.down()</code>/<code>ptt.up()</code>, which is what triggers the hotkey injection that makes Zello actually transmit the relayed audio.</li>
+</ul>
+
 <h2>How It Works</h2>
 
 <p>ZPTTLink listens for a PTT signal from your radio interface — either a serial control line (DigiRig DTR/RTS) or a USB HID GPIO line (CM108/CM119). When it fires, ZPTTLink does two things in parallel:</p>
@@ -278,10 +314,12 @@ adb install /path/to/zello.apk</code></pre>
 
 <p>Microphone/Zello audio is routed to the radio's audio output via a virtual audio driver, creating the RF-to-Zello link.</p>
 
+<p>The above describes the hardware backends (DigiRig/CM108/Signalink). The <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a> works differently — it's genuinely full duplex over the network rather than one-way to a local device; see that section for how audio actually flows in that mode.</p>
+
 <h2>Known Limitations</h2>
 
 <ul>
-  <li><strong>TX-only.</strong> ZPTTLink currently bridges audio from Zello/microphone to the radio. It does not yet route received radio audio back into Zello as a virtual microphone — that RX path is unbuilt.</li>
+  <li><strong>TX-only for the hardware backends.</strong> With a physical radio (DigiRig/CM108/Signalink), ZPTTLink bridges audio from Zello/microphone to the radio only — it does not route received radio audio back into Zello as a virtual microphone. The <a href="#asterisk-usrp-backend">Asterisk backend</a> does not have this limitation; USRP is duplex by design.</li>
   <li><strong>ADB PTT is edge-triggered, not press-and-hold.</strong> See <a href="#android-runtime-targets">Android Runtime Targets</a> — it requires Zello's hotkey mode set to Toggle, not Hold.</li>
   <li><strong>No audio bridge into docker-android by default.</strong> Both supported docker-android images run headless with no audio passthrough out of the box; wiring that up is a manual PulseAudio-over-network step outside ZPTTLink's control.</li>
   <li><strong>Waydroid input isolation.</strong> Synthetic key events (ydotool or otherwise) injected on the host are not guaranteed to reach an app running inside Waydroid's container; ADB is the more reliable fallback there too.</li>
@@ -302,6 +340,7 @@ Full license text: https://opensource.org/licenses/MIT
 <h2>Related Projects</h2>
 
 <ul>
+  <li><a href="https://www.asterisk.org/">Asterisk</a></li>
   <li><a href="https://github.com/skuep/AIOC">AIOC – All-In-One Cable</a></li>
   <li><a href="https://github.com/ExistentialAudio/BlackHole">BlackHole (macOS)</a></li>
   <li><a href="https://github.com/alsa-project/alsa-utils">ALSA Utils / Loopback (Linux)</a></li>

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 
 setup(
     name="zpttlink",
-    version="2.1.0",
-    description="Zello <-> radio PTT gateway with deterministic DTR/RTS/CM108 PTT and pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android",
+    version="3.0.0",
+    description="Open-source Zello <-> radio/Asterisk linking bridge: DTR/RTS/CM108 hardware PTT or Asterisk (USRP) over the network, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android",
     author="Max Hayim",
     packages=find_packages(),
     install_requires=[

--- a/zpttlink/__init__.py
+++ b/zpttlink/__init__.py
@@ -2,4 +2,4 @@
 ZPTTLink package initialization.
 """
 
-__version__ = "2.1.0"
+__version__ = "3.0.0"

--- a/zpttlink/gui.py
+++ b/zpttlink/gui.py
@@ -42,7 +42,7 @@ except ImportError:
     from main import DEFAULT_CONFIG, list_audio_devices, list_serial_ports, load_config
 
 
-APP_TITLE = "ZPTTLink 2.1.0"
+APP_TITLE = "ZPTTLink 3.0.0"
 CONFIG_PATH = Path("config.json")
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -322,6 +322,12 @@ class MainWindow(QMainWindow):
         group = QGroupBox("Connection")
         layout = QFormLayout(group)
 
+        self.radio_type_combo = QComboBox()
+        self.radio_type_combo.addItems(["auto", "digirig", "cm108", "signalink", "asterisk"])
+        self.radio_type_combo.setCurrentText(self.cfg.get("radio_type", "auto"))
+        self.radio_type_combo.currentTextChanged.connect(self._on_radio_type_changed)
+        layout.addRow("Radio Backend", self.radio_type_combo)
+
         serial_row = QHBoxLayout()
         self.serial_combo = QComboBox()
         self.btn_refresh_serial = QPushButton("Refresh")
@@ -345,7 +351,34 @@ class MainWindow(QMainWindow):
         )
         layout.addRow("", self.chk_ignore_initial_ptt)
 
+        asterisk_cfg = self.cfg.get("asterisk", {})
+        self.asterisk_host_edit = QLineEdit(asterisk_cfg.get("host", "127.0.0.1"))
+        self.asterisk_host_edit.setPlaceholderText("127.0.0.1 (same box) or a remote Asterisk IP")
+        layout.addRow("Asterisk Host", self.asterisk_host_edit)
+
+        self.asterisk_port_spin = QSpinBox()
+        self.asterisk_port_spin.setRange(1, 65535)
+        self.asterisk_port_spin.setValue(int(asterisk_cfg.get("port", 32001)))
+        layout.addRow("Asterisk Port", self.asterisk_port_spin)
+
+        self.lbl_asterisk_hint = QLabel(
+            "Connects to a local or remote Asterisk instance over the network (USRP "
+            "protocol) instead of physical radio hardware. Needs hotkey_enabled + an "
+            "injection_mode so incoming audio actually relays into Zello — see README."
+        )
+        self.lbl_asterisk_hint.setWordWrap(True)
+        layout.addRow("", self.lbl_asterisk_hint)
+
+        self._on_radio_type_changed(self.radio_type_combo.currentText())
         return group
+
+    def _on_radio_type_changed(self, value: str):
+        is_asterisk = value == "asterisk"
+        for w in (self.serial_combo, self.btn_refresh_serial, self.ptt_mode_combo, self.chk_ignore_initial_ptt):
+            w.setEnabled(not is_asterisk)
+        for w in (self.asterisk_host_edit, self.asterisk_port_spin):
+            w.setEnabled(is_asterisk)
+        self.lbl_asterisk_hint.setVisible(is_asterisk)
 
     def _build_android_target_group(self):
         group = QGroupBox("Android Target (Zello host)")
@@ -661,6 +694,12 @@ class MainWindow(QMainWindow):
         payload["ignore_initial_ptt_state"] = self.chk_ignore_initial_ptt.isChecked()
         payload["injection_mode"] = self.injection_mode_combo.currentText()
         payload["adb_serial"] = self.adb_serial_edit.text().strip() or None
+        payload["radio_type"] = self.radio_type_combo.currentText()
+        payload["asterisk"] = {
+            "host": self.asterisk_host_edit.text().strip() or "127.0.0.1",
+            "port": self.asterisk_port_spin.value(),
+            "local_port": self.cfg.get("asterisk", {}).get("local_port", 0),
+        }
 
         payload["vox"] = {
             "enabled": self.chk_vox_enabled.isChecked(),
@@ -690,6 +729,13 @@ class MainWindow(QMainWindow):
 
         hotkey = self.hotkey_edit.text().strip()
         ptt_mode = self.ptt_mode_combo.currentText()
+
+        radio_type = self.radio_type_combo.currentText()
+        if radio_type and radio_type != "auto":
+            args.extend(["--radio-type", radio_type])
+        if radio_type == "asterisk":
+            args.extend(["--asterisk-host", self.asterisk_host_edit.text().strip() or "127.0.0.1"])
+            args.extend(["--asterisk-port", str(self.asterisk_port_spin.value())])
 
         if hotkey and not self.chk_no_hotkey.isChecked():
             args.extend(["--key", hotkey])

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -3,9 +3,11 @@ import json
 import logging
 import os
 import platform
+import queue
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import threading
@@ -220,6 +222,15 @@ DEFAULT_CONFIG = {
         "active_low": False
     },
 
+    # radio_type: "asterisk" connects to a local or remote Asterisk instance (app_rpt)
+    # over the USRP protocol instead of a physical radio interface. No serial/USB
+    # device is used for this backend.
+    "asterisk": {
+        "host": "127.0.0.1",
+        "port": 32001,
+        "local_port": 0
+    },
+
     "logging": {
         "level": "INFO",
         "file": DEFAULT_LOGFILE
@@ -421,6 +432,9 @@ def apply_active_low(state, active_low):
 
 class RadioInterfaceBase:
     name = "base"
+    # True for backends that carry audio themselves (e.g. over a network socket),
+    # rather than through the local sd.Stream device pair like the hardware backends.
+    transports_audio = False
 
     def open(self):
         pass
@@ -583,6 +597,167 @@ class SignalinkRadio(RadioInterfaceBase):
         pass
 
 
+# USRP is the UDP audio+PTT wire format used by Asterisk's app_rpt (chan_usrp/simpleusb)
+# to let an external program act as a "radio" node without being a compiled Asterisk
+# channel driver. 32-byte header (big-endian) + 160 samples (20ms) of 16-bit signed
+# linear PCM audio at 8000 Hz, mono, when type == USRP_TYPE_VOICE.
+USRP_TYPE_VOICE = 0
+USRP_TYPE_DTMF = 1
+USRP_TYPE_TEXT = 2
+USRP_TYPE_PING = 3
+USRP_SAMPLE_RATE = 8000
+USRP_FRAME_SAMPLES = 160  # 20ms @ 8kHz
+USRP_HEADER_FMT = ">4sIIIIIII"
+USRP_HEADER_LEN = struct.calcsize(USRP_HEADER_FMT)
+
+
+def pcm16_frame(mono_float, target_len):
+    clipped = np.clip(mono_float, -1.0, 1.0)
+    ints = (clipped * 32767.0).astype("<i2")
+    if ints.size < target_len:
+        ints = np.pad(ints, (0, target_len - ints.size))
+    elif ints.size > target_len:
+        ints = ints[:target_len]
+    return ints
+
+
+def fit_frame(mono_float, target_len):
+    if mono_float.size < target_len:
+        mono_float = np.pad(mono_float, (0, target_len - mono_float.size))
+    elif mono_float.size > target_len:
+        mono_float = mono_float[:target_len]
+    return mono_float.reshape(-1, 1).astype(np.float32)
+
+
+def resample_linear(samples, src_rate, dst_rate):
+    if samples.size == 0 or src_rate == dst_rate:
+        return samples.astype(np.float32)
+    duration = samples.shape[0] / float(src_rate)
+    dst_len = int(round(duration * dst_rate))
+    if dst_len <= 0:
+        return np.zeros(0, dtype=np.float32)
+    src_idx = np.linspace(0, samples.shape[0] - 1, num=dst_len)
+    return np.interp(src_idx, np.arange(samples.shape[0]), samples).astype(np.float32)
+
+
+class AsteriskRadio(RadioInterfaceBase):
+    """Connects to a local or remote Asterisk instance (app_rpt) over the USRP
+    protocol, in place of a physical radio interface. Unlike the hardware backends,
+    this one carries audio itself over the network rather than through a local
+    sd.Stream device pair - see transports_audio."""
+
+    name = "asterisk"
+    transports_audio = True
+
+    def __init__(self, host, port, local_port=0):
+        self.host = host
+        self.port = int(port)
+        self.local_port = int(local_port or 0)
+        self.sock = None
+        self.seq = 0
+        self.seq_lock = threading.Lock()
+        self.rx_queue = queue.Queue(maxsize=50)
+        self.rx_thread = None
+        self.stop_flag = threading.Event()
+
+    def open(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(("0.0.0.0", self.local_port))
+        self.sock.settimeout(1.0)
+        self.stop_flag.clear()
+        self.rx_thread = threading.Thread(target=self._recv_loop, daemon=True)
+        self.rx_thread.start()
+        bound_port = self.sock.getsockname()[1]
+        logger.info(
+            f"Asterisk USRP backend: sending to {self.host}:{self.port}, "
+            f"listening on 0.0.0.0:{bound_port}"
+        )
+
+    def _recv_loop(self):
+        while not self.stop_flag.is_set():
+            try:
+                data, _ = self.sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            if len(data) < USRP_HEADER_LEN:
+                continue
+            try:
+                eye, seq, memory, keyup, talkgroup, ptype, mpxid, reserved = struct.unpack(
+                    USRP_HEADER_FMT, data[:USRP_HEADER_LEN]
+                )
+            except struct.error:
+                continue
+            if eye != b"USRP" or ptype != USRP_TYPE_VOICE or np is None:
+                continue
+
+            payload = data[USRP_HEADER_LEN:USRP_HEADER_LEN + USRP_FRAME_SAMPLES * 2]
+            if not payload:
+                continue
+            ints = np.frombuffer(payload, dtype="<i2")
+            floats = ints.astype(np.float32) / 32768.0
+            item = (floats, bool(keyup))
+
+            try:
+                self.rx_queue.put_nowait(item)
+            except queue.Full:
+                try:
+                    self.rx_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                try:
+                    self.rx_queue.put_nowait(item)
+                except queue.Full:
+                    pass
+
+    def recv_audio_nowait(self):
+        try:
+            return self.rx_queue.get_nowait()
+        except queue.Empty:
+            return None
+
+    def send_audio(self, pcm16_array, keyup, dry=False):
+        if dry:
+            return
+        if self.sock is None:
+            return
+        with self.seq_lock:
+            self.seq += 1
+            seq = self.seq
+        header = struct.pack(
+            USRP_HEADER_FMT, b"USRP", seq, 0, 1 if keyup else 0, 0, USRP_TYPE_VOICE, 0, 0
+        )
+        try:
+            self.sock.sendto(header + pcm16_array.tobytes(), (self.host, self.port))
+        except Exception as e:
+            logger.error(f"USRP send failed: {e}")
+
+    def ptt_on(self, dry=False):
+        # Outbound keyup is driven per-frame from audio_callback (see main()), not
+        # here - this exists so PTTController's hotkey-injection plumbing still has
+        # a backend method to call when relaying an Asterisk-side keyup into Zello.
+        if not dry:
+            logger.debug("Asterisk backend: relayed PTT DOWN (from remote keyup)")
+
+    def ptt_off(self, dry=False):
+        if not dry:
+            logger.debug("Asterisk backend: relayed PTT UP (from remote keyup)")
+
+    def close(self):
+        self.stop_flag.set()
+        try:
+            if self.sock is not None:
+                self.sock.close()
+        except Exception:
+            pass
+        self.sock = None
+        if self.rx_thread is not None:
+            self.rx_thread.join(timeout=2.0)
+            self.rx_thread = None
+
+
 def choose_radio_type(cfg, args):
     explicit = getattr(args, "radio_type", None)
     if explicit:
@@ -666,6 +841,20 @@ def build_radio_backend(cfg, args):
             active_low=active_low,
             ignore_initial_state=ignore_initial_state,
         )
+
+    if radio_type == "asterisk":
+        if np is None:
+            logger.error("numpy is required for the Asterisk USRP backend.")
+            sys.exit(2)
+        ast_cfg = cfg.get("asterisk", {})
+        host = args.asterisk_host or ast_cfg.get("host") or "127.0.0.1"
+        port = int(args.asterisk_port if args.asterisk_port is not None else ast_cfg.get("port", 32001))
+        local_port = int(
+            args.asterisk_local_port
+            if args.asterisk_local_port is not None
+            else ast_cfg.get("local_port", 0)
+        )
+        return AsteriskRadio(host=host, port=port, local_port=local_port)
 
     if radio_type == "signalink":
         return SignalinkRadio()
@@ -966,7 +1155,7 @@ def maybe_log_level(level, enabled):
 def main():
     global keyboard, logger, audio_stream
 
-    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 2.1 TX bridge")
+    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 3.0 Zello/radio/Asterisk bridge")
     parser.add_argument("--config", default=DEFAULT_CONFIG_FILE)
     parser.add_argument("--key", help="Hotkey to send to Zello")
     parser.add_argument("--serial", help="Serial port override")
@@ -978,8 +1167,20 @@ def main():
         "(default 30; helps on headless boot where udev lags service start). 0 disables waiting.",
     )
     parser.add_argument("--baud", type=int, default=None)
-    parser.add_argument("--radio-type", choices=["auto", "cm108", "digirig", "signalink"], default=None)
+    parser.add_argument(
+        "--radio-type",
+        choices=["auto", "cm108", "digirig", "signalink", "asterisk"],
+        default=None,
+    )
     parser.add_argument("--ptt-output", choices=["none", "dtr", "rts"], default=None)
+    parser.add_argument("--asterisk-host", default=None, help="Asterisk USRP peer host/IP")
+    parser.add_argument("--asterisk-port", type=int, default=None, help="Asterisk USRP peer port")
+    parser.add_argument(
+        "--asterisk-local-port",
+        type=int,
+        default=None,
+        help="Local UDP port to bind for the Asterisk USRP backend (0 = OS-assigned)",
+    )
     parser.add_argument("--no-hotkey", action="store_true")
     parser.add_argument("--test-ptt", action="store_true")
     parser.add_argument("--list-serial", action="store_true")
@@ -1235,12 +1436,62 @@ def main():
     samplerate = choose_samplerate(input_index, output_index, default_sr=configured_sr)
     logger.info(f"TX samplerate: {samplerate}")
 
+    usrp_local_keyed = [False]
+    usrp_remote_keyed = [False]
+
+    if backend.transports_audio:
+        logger.info(
+            f"Asterisk USRP mode: local audio keys Asterisk directly; incoming Asterisk "
+            f"keyup relays into Zello via {'hotkey injection' if hotkey_enabled else 'PTT UP/DOWN log only (hotkey injection disabled!)'}."
+        )
+        if not hotkey_enabled:
+            logger.warning(
+                "hotkey_enabled is False with radio_type=asterisk: audio arriving from "
+                "Asterisk will be written into Zello's mic input, but Zello won't be told "
+                "to transmit it unless Zello's own VOX is enabled. Set force_serial_ptt: "
+                "false and configure injection_mode to relay it properly."
+            )
+
     def audio_callback(indata, outdata, frames, time_info, status):
         if status:
             logger.warning(f"TX callback status: {status}")
 
         level = rms_level(indata)
         maybe_log_level(level, vox_log_levels)
+
+        if backend.transports_audio:
+            # Outbound: local Zello audio -> Asterisk. Local VOX (reusing `gate`)
+            # decides the outbound keyup flag; no hotkey injection needed here since
+            # Zello is already producing this audio on its own.
+            action = gate.process(level)
+            if action == "start":
+                usrp_local_keyed[0] = True
+                logger.info("USRP TX keyup -> ON (local VOX)")
+            elif action == "stop":
+                usrp_local_keyed[0] = False
+                logger.info("USRP TX keyup -> OFF (local VOX)")
+
+            mono_in = np.asarray(indata, dtype=np.float32).reshape(-1)
+            mono_8k = resample_linear(mono_in, samplerate, USRP_SAMPLE_RATE)
+            pcm16 = pcm16_frame(mono_8k, USRP_FRAME_SAMPLES)
+            backend.send_audio(pcm16, keyup=usrp_local_keyed[0], dry=args.dry_run)
+
+            # Inbound: Asterisk -> Zello mic input. The remote keyup edge drives
+            # ptt.down()/up() so hotkey injection actually relays it into Zello.
+            rx = backend.recv_audio_nowait()
+            if rx is not None:
+                rx_samples, rx_keyup = rx
+                if rx_keyup and not usrp_remote_keyed[0]:
+                    usrp_remote_keyed[0] = True
+                    ptt.down(source="asterisk-rx")
+                elif not rx_keyup and usrp_remote_keyed[0]:
+                    usrp_remote_keyed[0] = False
+                    ptt.up(source="asterisk-rx")
+                up = resample_linear(rx_samples, USRP_SAMPLE_RATE, samplerate)
+                outdata[:] = fit_frame(up, frames)
+            else:
+                zero_out(outdata)
+            return
 
         try:
             shaped = sanitize_audio(
@@ -1263,14 +1514,19 @@ def main():
         elif action == "stop":
             ptt.up(source="vox")
 
+    stream_kwargs = dict(
+        device=(input_index, output_index),
+        samplerate=samplerate,
+        channels=1,
+        dtype="float32",
+        callback=audio_callback,
+    )
+    if backend.transports_audio:
+        # Align each callback tick with one 20ms USRP frame.
+        stream_kwargs["blocksize"] = int(round(samplerate * 0.02))
+
     try:
-        audio_stream = sd.Stream(
-            device=(input_index, output_index),
-            samplerate=samplerate,
-            channels=1,
-            dtype="float32",
-            callback=audio_callback,
-        )
+        audio_stream = sd.Stream(**stream_kwargs)
         audio_stream.start()
         logger.info("TX audio stream active.")
     except Exception as e:
@@ -1284,7 +1540,7 @@ def main():
     logger.info(
         f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, dry_run={args.dry_run})"
     )
-    logger.info("ZPTTLink 2.1 TX bridge is running successfully! (Ctrl+C to exit)")
+    logger.info("ZPTTLink 3.0 bridge is running successfully! (Ctrl+C to exit)")
     sd_notify("READY=1")
 
     exit_code = 0

--- a/zpttlink/pyproject.toml
+++ b/zpttlink/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "zpttlink"
 # We read the version from the package to keep it in one place
 dynamic = ["version", "readme"]
-description = "Zello <-> radio PTT gateway with deterministic DTR/RTS/CM108 PTT and pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android"
+description = "Open-source Zello <-> radio/Asterisk linking bridge: DTR/RTS/CM108 hardware PTT or Asterisk (USRP) over the network, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android"
 authors = [{ name = "Max Hayim" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -31,7 +31,7 @@ macos = ["pyobjc>=9.2; sys_platform == 'darwin'"]
 linux = ["pulsectl>=23.5.2; sys_platform == 'linux'"]
 
 # PyPI metadata
-keywords = ["zello", "ptt", "hamradio", "gmrs", "audio", "serial", "bluestacks", "waydroid", "docker-android", "adb", "raspberry-pi"]
+keywords = ["zello", "ptt", "hamradio", "gmrs", "audio", "serial", "bluestacks", "waydroid", "docker-android", "adb", "raspberry-pi", "asterisk", "app_rpt", "usrp"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary

v3.0: a new `radio_type: "asterisk"` backend, **additive** alongside the existing DigiRig/CM108/Signalink hardware backends — nothing about the Zello side or existing hardware paths changes.

Instead of physical radio hardware, this backend connects to a local or remote [Asterisk](https://www.asterisk.org/) instance over the network using the **USRP protocol** (the UDP audio+PTT wire format Asterisk's `app_rpt`/`chan_usrp` uses to let an external program act as a "radio" node without being a compiled Asterisk channel driver). It runs identically whether co-located on the same Pi/computer as Asterisk or talking to a remote instance over LAN/VPN — it's just a UDP `host:port` peer either way, which is why this needs to run on the same class of hardware Asterisk nodes already run on.

Since USRP is inherently duplex, this is also where ZPTTLink's long-standing **TX-only limitation finally goes away — for this backend**. The hardware backends stay TX-only (unchanged); Asterisk mode genuinely routes audio both directions.

## How it works

- **Outbound (Zello → Asterisk):** local VOX (reusing the existing `AudioGate`) decides the `keyup` flag sent with each 20ms USRP frame. No hotkey injection involved — Zello's already producing that audio itself.
- **Inbound (Asterisk → Zello):** the received frame's `keyup` field drives `ptt.down()`/`ptt.up()`, which is what triggers hotkey injection (pynput/ydotool/adb, whichever `injection_mode` is configured) so the relayed audio actually gets transmitted into Zello's network — not just silently written into its mic input.
- A new numpy-based linear resampler bridges the device's configured samplerate (typically 48000) and USRP's fixed 8000 Hz mono requirement; stream blocksize is pinned to 20ms in this mode so each callback tick maps to exactly one USRP frame.

## Also in this PR

- Startup warning when `radio_type=asterisk` but `hotkey_enabled` is `False` — the hardware backends' correct default (`force_serial_ptt: true`) would otherwise silently break the Asterisk relay path.
- GUI: Radio Backend dropdown + Asterisk Host/Port fields, enabling/disabling serial-vs-network fields based on selection.
- README: new "Asterisk (USRP) Backend" section; Known Limitations rescoped so the TX-only note applies to the hardware backends only.
- Naming: references only "Asterisk"/`app_rpt`/USRP throughout — no specific linking network or commercial vendor named, per direction from the repo owner (legal reasons).
- Version bumped to **3.0.0** — genuine new integration surface, not a patch.

## Test plan

- [x] Unit-level USRP packet framing: send/receive round-trip, sequence increment, malformed/non-USRP packet correctly rejected — against a raw UDP peer script
- [x] Resampling fidelity: 0.9999 correlation on a 440Hz tone round-tripped 48kHz→8kHz→48kHz
- [x] Full end-to-end daemon run against a scripted fake Asterisk peer, with a real audio stream and real pynput injection: confirmed the peer received a correctly-framed TX packet, and confirmed the peer sending `keyup=1` then `keyup=0` correctly drove `PTT DOWN (asterisk-rx)` → real key press → `PTT UP (asterisk-rx)` → release
- [x] Confirmed the `hotkey_enabled=False` misconfiguration warning fires
- [x] Regression-tested: existing DigiRig hardware backend (`--test-ptt` and the full audio-daemon VOX loop) unaffected by the refactor
- [ ] **Not tested against a real Asterisk instance** — no Asterisk/`app_rpt` available in this environment. Packet framing was validated against the documented USRP wire format and a controlled fake peer, not a live node. Would strongly recommend a real-world test before relying on this for anything live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
