### PR TITLE
Add RX audio for hardware backends; split Pi tutorial by node type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>An open-source, all-in-one Zello ↔ radio ↔ Asterisk linking bridge with deterministic PTT control</strong>
+  <strong>An open-source, all-in-one linking bridge</strong>
 </p>
 
 <p align="center">
@@ -18,7 +18,9 @@
 
 <h1>ZPTTLink</h1>
 
-<p>ZPTTLink is an open-source, cross-platform application that bridges Zello with a radio-side target of your choice: physical radio gateway hardware like the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>, <strong>or</strong> a local/remote <a href="https://www.asterisk.org/">Asterisk</a> instance over the network (no radio hardware required for that leg — see <a href="#asterisk-usrp-backend">Asterisk (USRP) Backend</a>). Both are just different <code>radio_type</code> backends; nothing about the Zello side changes. It enables seamless Push-to-Talk (PTT) control and audio routing, allowing users to link RF radios (or an Asterisk node) to Zello using only a computer. Zello itself can run inside <a href="https://www.bluestacks.com/">BlueStacks</a> (macOS), <a href="https://waydro.id/">Waydroid</a> (Linux), or a dockerized Android emulator such as <a href="https://github.com/budtmo/docker-android">budtmo/docker-android</a> or <a href="https://github.com/HQarroum/docker-android">HQarroum/docker-android</a> — see <a href="#android-runtime-targets">Android Runtime Targets</a> below for how PTT reaches each one.</p>
+<p>ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android.</p>
+
+<p>Compatible radio interfaces include the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>, CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables — see <a href="#requirements">Requirements</a>. Both the radio side and the Zello side are configurable independently: pick a hardware backend or <a href="#asterisk-usrp-backend">Asterisk (USRP)</a> for the radio side, and BlueStacks/Waydroid/docker-android for where Zello runs — see <a href="#android-runtime-targets">Android Runtime Targets</a>.</p>
 
 <p>This tool is ideal for GMRS and ham radio operators, emergency communications volunteers, and hobbyists who want to build a software-based radio gateway.</p>
 
@@ -69,6 +71,7 @@
     </ul>
   </li>
   <li>Direct hardware PTT via serial DTR/RTS or CM108 GPIO, independent of key injection entirely — the most reliable option when the radio, not the app, is the thing you need to key</li>
+  <li><strong>Full duplex audio</strong>: Zello → radio (TX) plus an optional, independent radio → Zello (<a href="#rx-audio-hardware-backends">RX</a>) path for the hardware backends, and always-duplex for the <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a>, since USRP is bidirectional by design</li>
   <li>Cross-platform support for Windows, macOS, and Linux (including Raspberry Pi)</li>
   <li><strong>Two operating modes:</strong>
     <ul>
@@ -85,6 +88,7 @@
       <li>Runtime start/stop controls</li>
       <li>Config editor with save button</li>
       <li>Android target / injection mode selector, with an ADB serial field for docker-android targets</li>
+      <li>RX audio device selectors and VOX threshold, with a one-click enable/disable toggle</li>
     </ul>
   </li>
   <li>Audio routing via <a href="https://vb-audio.com/Cable/">VB-Cable (Windows)</a>, <a href="https://existential.audio/blackhole/">BlackHole (macOS)</a>, or <a href="https://www.alsa-project.org/wiki/Loopback_Device">ALSA Loopback (Linux)</a></li>
@@ -303,6 +307,29 @@ adb install /path/to/zello.apk</code></pre>
   <li><strong>Asterisk → Zello:</strong> incoming USRP voice frames are resampled up to the device rate and written into <code>audio_output_index</code> (point this at whatever virtual audio device feeds Zello's <em>microphone</em> input — the reverse role <code>audio_output_index</code> plays for the hardware backends, where it feeds the radio's TX audio input instead). The incoming frame's <code>keyup</code> field drives <code>ptt.down()</code>/<code>ptt.up()</code>, which is what triggers the hotkey injection that makes Zello actually transmit the relayed audio.</li>
 </ul>
 
+<h2>RX Audio (Hardware Backends)</h2>
+
+<p>The DigiRig/CM108/Signalink backends now support a second, independent audio path: the radio's <em>received</em> audio relayed back into Zello. This is off by default (matching earlier versions) — set both <code>rx_audio_input_index</code> and <code>rx_audio_output_index</code> to enable it, or use the GUI's <strong>Enable RX (radio → Zello)</strong> checkbox in the Audio panel.</p>
+
+<pre><code>{
+  "rx_audio_input_index": 3,
+  "rx_audio_output_index": 4,
+  "rx_vox": {
+    "enabled": true,
+    "threshold": 0.01,
+    "attack_ms": 20,
+    "release_ms": 150,
+    "hang_ms": 200
+  },
+  "audio": {
+    "rx_gain": 0.5
+  }
+}</code></pre>
+
+<p>This runs as a second, independent audio stream alongside the existing TX one: <code>rx_audio_input_index</code> captures the radio's received audio, an RX-side VOX gate (separately tunable from the TX <code>vox</code> block — receive-audio levels are rarely close to Zello's loopback level) decides when there's real traffic, and while active the audio is written into <code>rx_audio_output_index</code> (point this at whatever virtual device feeds Zello's <em>microphone</em> input) while <code>ptt.down()</code>/<code>ptt.up()</code> fires so hotkey injection actually relays it into Zello's network — not just silently played into its mic input.</p>
+
+<p><strong>Important wiring note:</strong> triggering RX also calls the configured backend's <code>ptt_on()</code>/<code>ptt_off()</code> — the same call TX-side VOX uses to key the radio. That's correct and intentional for a proper repeater topology with <strong>separate RX and TX radios</strong> (RX radio's audio feeds <code>rx_audio_input_index</code>; the backend's DTR/RTS/GPIO line keys the separate TX radio). It is very likely <strong>wrong</strong> for a single-transceiver setup, where keying the same radio's PTT while its own RX audio is mid-relay will cut off the very audio you're trying to relay (most transceivers mute RX while transmitting). If you only have one radio, either leave RX disabled, or set <code>ptt_output: "none"</code> so the backend's PTT line is never asserted and RX only drives hotkey injection into Zello.</p>
+
 <h2>How It Works</h2>
 
 <p>ZPTTLink listens for a PTT signal from your radio interface — either a serial control line (DigiRig DTR/RTS) or a USB HID GPIO line (CM108/CM119). When it fires, ZPTTLink does two things in parallel:</p>
@@ -312,14 +339,14 @@ adb install /path/to/zello.apk</code></pre>
   <li><strong>Keys the radio directly</strong> via serial DTR/RTS or CM108 GPIO, independent of whether the key injection actually reached Zello — this is the deterministic path the project name refers to.</li>
 </ol>
 
-<p>Microphone/Zello audio is routed to the radio's audio output via a virtual audio driver, creating the RF-to-Zello link.</p>
+<p>Microphone/Zello audio is routed to the radio's audio output via a virtual audio driver, creating the Zello-to-RF link. If <a href="#rx-audio-hardware-backends">RX audio</a> is configured, the reverse leg (radio's received audio → Zello) runs as a second, independent stream, closing the loop into a full duplex bridge.</p>
 
-<p>The above describes the hardware backends (DigiRig/CM108/Signalink). The <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a> works differently — it's genuinely full duplex over the network rather than one-way to a local device; see that section for how audio actually flows in that mode.</p>
+<p>The <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a> works differently from all of the above — audio flows over the network rather than to/from local devices; see that section for how it actually works in that mode.</p>
 
 <h2>Known Limitations</h2>
 
 <ul>
-  <li><strong>TX-only for the hardware backends.</strong> With a physical radio (DigiRig/CM108/Signalink), ZPTTLink bridges audio from Zello/microphone to the radio only — it does not route received radio audio back into Zello as a virtual microphone. The <a href="#asterisk-usrp-backend">Asterisk backend</a> does not have this limitation; USRP is duplex by design.</li>
+  <li><strong>Hardware-backend RX assumes a separate RX radio if PTT output is enabled.</strong> See the wiring note in <a href="#rx-audio-hardware-backends">RX Audio</a> — on a single transceiver, keying its own PTT during RX relay will cut off the audio being relayed. Use <code>ptt_output: "none"</code> for single-radio RX.</li>
   <li><strong>ADB PTT is edge-triggered, not press-and-hold.</strong> See <a href="#android-runtime-targets">Android Runtime Targets</a> — it requires Zello's hotkey mode set to Toggle, not Hold.</li>
   <li><strong>No audio bridge into docker-android by default.</strong> Both supported docker-android images run headless with no audio passthrough out of the box; wiring that up is a manual PulseAudio-over-network step outside ZPTTLink's control.</li>
   <li><strong>Waydroid input isolation.</strong> Synthetic key events (ydotool or otherwise) injected on the host are not guaranteed to reach an app running inside Waydroid's container; ADB is the more reliable fallback there too.</li>

--- a/docs/raspberry-pi-repeater-deployment.md
+++ b/docs/raspberry-pi-repeater-deployment.md
@@ -1,20 +1,30 @@
 # Deploying ZPTTLink on a Raspberry Pi at a repeater site
 
-This walks through building an unattended ZPTTLink box: a Raspberry Pi, a radio
-interface, and a copy of Zello, sealed in an enclosure and left running next to
-a repeater with nobody around to babysit it. It assumes you've read the main
+This walks through building an unattended ZPTTLink box: a Raspberry Pi, Zello,
+and a radio-side target, sealed in an enclosure and left running next to a
+repeater with nobody around to babysit it. It assumes you've read the main
 [README](../README.md), especially [Android Runtime
-Targets](../README.md#android-runtime-targets) and [Known
+Targets](../README.md#android-runtime-targets), [Asterisk (USRP)
+Backend](../README.md#asterisk-usrp-backend), and [Known
 Limitations](../README.md#known-limitations).
 
-**Read this first if that's your plan:** ZPTTLink today is a **TX-only** bridge
-— it sends Zello/mic audio to the radio and keys the radio to match, but it does
-not yet route received radio audio back into Zello. If your goal is a full
-duplex Zello↔repeater gateway (talk on Zello, hear the repeater, and vice
-versa), that RX path doesn't exist yet — build and test the TX path first, and
-track the RX gap before you seal the box and drive away.
+Zello is always one side of the bridge — that part of the setup (Waydroid +
+Zello) is identical either way. What differs is the *other* side, and that's
+what this guide splits into two node types:
+
+- **Standard node** — Zello bridged to a physical radio (AIOC/CM108/DigiRig)
+  cabled directly to this Pi.
+- **Asterisk node** — Zello bridged to a local or remote
+  [Asterisk](https://www.asterisk.org/) instance over the network (USRP
+  protocol), no radio hardware on this Pi at all.
+
+You can also run *both* on the same box (two ZPTTLink processes, two configs)
+if you want Zello reachable from both a local radio and an Asterisk instance —
+each `radio_type` is independent per config.json.
 
 ## 1. What you're building
+
+**Standard node:**
 
 ```
         Zello network
@@ -38,9 +48,35 @@ track the RX gap before you seal the box and drive away.
                                   Radio ↔ Repeater
 ```
 
-Everything above the USB interface runs on one Raspberry Pi.
+**Asterisk node:**
+
+```
+        Zello network
+              │
+      ┌───────▼────────┐
+      │  Waydroid (or   │   Zello audio + PTT hotkey
+      │  docker-android)│──────────────┐
+      └────────────────┘               │
+              ▲                        ▼
+              │ ADB (optional)   ┌─────────────┐
+              └──────────────────│  ZPTTLink   │
+                                  │ (this repo) │
+                                  └──────┬──────┘
+                                         │ UDP / USRP protocol
+                                         ▼
+                                  ┌─────────────┐
+                                  │  Asterisk   │   same box (127.0.0.1)
+                                  │  (app_rpt)  │   or a separate one on the LAN
+                                  └──────┬──────┘
+                                         ▼
+                              (whatever Asterisk is linked to)
+```
+
+Everything above the divergent bottom leg runs on one Raspberry Pi either way.
 
 ## 2. Hardware
+
+Shared, regardless of node type:
 
 - **Raspberry Pi 4 or 5, 4GB+ RAM.** Waydroid needs a real 64-bit kernel and
   enough RAM to run an Android userspace comfortably alongside ZPTTLink's audio
@@ -49,24 +85,40 @@ Everything above the USB interface runs on one Raspberry Pi.
   is the single biggest reliability upgrade you can make for a box that will
   never get a graceful shutdown — SD cards corrupt far more easily under power
   loss than a proper SSD, and this box *will* lose power eventually.
-- **AIOC, CM108/CM119-based, or DigiRig USB interface** cabled to your radio.
 - **A quality 5V/3A (or PD) power supply**, and ideally a small UPS (a PiJuice
   HAT or similar supercap/battery UPS) so a brief power blip doesn't corrupt
   the filesystem mid-write. At minimum, this is cheap insurance against the
   exact failure mode ("nobody's there to power-cycle it") this whole tutorial
   is trying to prevent.
+
+**Standard node only:**
+
+- **AIOC, CM108/CM119-based, or DigiRig USB interface** cabled to your radio.
 - **A vented, weatherproof enclosure.** Sealed plastic boxes in direct sun
-  turn into ovens; the Pi will thermal-throttle (or shut down) well before it's
-  actually damaged, but throttling under load can still disrupt audio timing.
-  Use a light-colored, ventilated (but weather-sealed against driven rain)
-  enclosure, and add a heatsink/fan if it'll see summer sun.
+  turn into ovens; the Pi will thermal-throttle (or shut down) well before
+  it's actually damaged, but throttling under load can still disrupt audio
+  timing. Use a light-colored, ventilated (but weather-sealed against driven
+  rain) enclosure, and add a heatsink/fan if it'll see summer sun.
+
+**Asterisk node only:**
+
+- No radio interface needed *on this Pi* — it's a network peer to Asterisk.
+- Reliable connectivity to wherever Asterisk runs: if co-located (`127.0.0.1`),
+  nothing extra; if remote, a stable LAN/VPN path (a flaky link here just
+  means dropped audio, not a hard failure — USRP is UDP, not a persistent
+  connection).
+- If this Pi *also* happens to be physically at a repeater/antenna site for
+  other reasons, the enclosure/thermal/RFI guidance below still applies.
 
 ### RF interference
 
-You're putting a Pi, USB cables, and (if you're using Ethernet) an unshielded
-cable run right next to a transmitter. Real-world RFI symptoms here look like
-garbled audio, a Pi that randomly reboots when the repeater keys up, or a USB
-serial port that drops out under transmit. Mitigate with:
+Applies whenever this box (or its network run) is physically near a
+transmitting antenna — most directly relevant to standard nodes with their own
+radio cabled in, but also relevant to an Asterisk node co-located with the
+Asterisk/app_rpt box that *does* have a radio attached. Real-world RFI
+symptoms here look like garbled audio, a Pi that randomly reboots when the
+repeater keys up, or a USB serial port that drops out under transmit.
+Mitigate with:
 
 - Ferrite chokes on the USB cable(s) and any Ethernet/power runs near the feed line
 - Keeping the Pi and its PSU physically separated from the antenna feedline/duplexer, not zip-tied to it
@@ -102,6 +154,9 @@ sudo usermod -aG dialout,audio,plugdev "$USER"
 
 ## 5. Install Waydroid and Zello
 
+This step is the same for both node types — Zello's side of the bridge never
+changes.
+
 ```bash
 curl https://repo.waydro.id | sudo bash
 sudo apt install -y waydroid
@@ -132,17 +187,22 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Find your devices:
-
 ```bash
-python -m zpttlink --list-serial
 python -m zpttlink --list-audio
 ```
 
-If `--list-audio` comes back empty, see the [PipeWire/ALSA
+If that comes back empty, see the [PipeWire/ALSA
 troubleshooting](../README.md#linux-notes) note in the README before going
 further — this is a common Pi-specific failure mode and there's a documented
 fix path for it.
+
+The rest of the configuration diverges by node type — pick your section below.
+
+## 7A. Standard node: configure ZPTTLink for a physical radio
+
+```bash
+python -m zpttlink --list-serial
+```
 
 Write `~/ZPTTLink/config.json` (or run the GUI once over VNC/X-forwarding
 with `python -m zpttlink --gui` and hit Save Config — same result):
@@ -179,10 +239,69 @@ Confirm hardware PTT works before wiring in Zello at all:
 python -m zpttlink --test-ptt --serial /dev/ttyACM0
 ```
 
-## 7. Install as a systemd user service
+**Optional: RX audio (radio → Zello).** Off by default. If you have a
+*separate* RX radio/receiver (standard repeater-controller topology — see
+[RX Audio](../README.md#rx-audio-hardware-backends) in the README for why a
+single transceiver is a bad fit here), add:
+
+```json
+{
+  "rx_audio_input_index": 3,
+  "rx_audio_output_index": 4,
+  "rx_vox": { "enabled": true, "threshold": 0.01 }
+}
+```
+
+Skip to [step 8](#8-install-as-a-systemd-user-service) once this is working.
+
+## 7B. Asterisk node: configure ZPTTLink for a network Asterisk backend
+
+No radio interface to find — point ZPTTLink at Asterisk instead. If Asterisk
+runs on this same Pi, use `127.0.0.1`; if it's elsewhere on your network, use
+that host's address.
+
+```json
+{
+  "radio_type": "asterisk",
+  "force_serial_ptt": false,
+  "disable_hotkey": false,
+  "injection_mode": "auto",
+
+  "asterisk": {
+    "host": "127.0.0.1",
+    "port": 32001,
+    "local_port": 0
+  },
+
+  "audio_input_index": 1,
+  "audio_output_index": 2
+}
+```
+
+**This is the one config where `force_serial_ptt: false` +
+`disable_hotkey: false` are required, not optional** — there's no hardware
+line for this backend to key, so hotkey injection is the only way audio
+arriving from Asterisk actually gets relayed into Zello's network. ZPTTLink
+logs a warning at startup if you get this backwards. See [Asterisk (USRP)
+Backend](../README.md#asterisk-usrp-backend) in the README for how audio
+flows in this mode (it's genuinely full duplex, unlike the standard-node
+TX path).
+
+Confirm connectivity and audio before relying on it:
+
+```bash
+python -m zpttlink --radio-type asterisk --asterisk-host 127.0.0.1 --asterisk-port 32001
+```
+
+Watch the log for `Asterisk USRP backend: sending to ...` and, once Asterisk
+is actually sending audio your way, `PTT DOWN (asterisk-rx)`.
+
+## 8. Install as a systemd user service
 
 Ready-made unit files are in [`deploy/systemd/`](../deploy/systemd/README.md).
-Short version:
+The service just runs `python -m zpttlink --config config.json` — since your
+node type lives entirely in `config.json`, the unit file itself is identical
+for both node types.
 
 ```bash
 mkdir -p ~/.config/systemd/user
@@ -201,15 +320,19 @@ Watch it come up:
 journalctl --user -u zpttlink.service -f
 ```
 
-You should see the serial/CM108 device get picked up, the audio stream start,
-and `PTT system ready`. Key the radio (or make some noise into the mic, if
-VOX is enabled) and confirm you see `PTT DOWN` / `PTT UP` and the radio
-actually transmits.
+Standard node: you should see the serial/CM108 device get picked up, the
+audio stream start, and `PTT system ready`. Key the radio (or make some noise
+into the mic, if VOX is enabled) and confirm you see `PTT DOWN` / `PTT UP`
+and the radio actually transmits.
 
-Reboot the whole Pi once here (`sudo reboot`) and confirm everything comes
-back up on its own — that's the real test, not just `systemctl start`.
+Asterisk node: you should see the USRP backend connect, `PTT system ready`,
+and — once there's traffic on the Asterisk side — `PTT DOWN (asterisk-rx)`.
 
-## 8. Unattended hardening
+Either way, reboot the whole Pi once here (`sudo reboot`) and confirm
+everything comes back up on its own — that's the real test, not just
+`systemctl start`.
+
+## 9. Unattended hardening
 
 - **Power loss:** if you skipped the UPS, at minimum use a filesystem that
   tolerates unclean shutdowns reasonably (ext4's default journaling helps, but
@@ -222,7 +345,8 @@ back up on its own — that's the real test, not just `systemctl start`.
 - **Network:** prefer wired Ethernet. If you're on WiFi/cellular at a remote
   site, consider a simple watchdog cron job that reboots the Pi if it can't
   reach the internet for N minutes — a box that silently drops off the network
-  and never recovers is just as bad as one that crashes.
+  and never recovers is just as bad as one that crashes. This matters even
+  more for an Asterisk node, since the whole radio-side leg is the network.
 - **Remote access without port-forwarding:** most repeater sites aren't going
   to give you a public IP to port-forward into. Consider
   [Tailscale](https://tailscale.com/) or ZeroTier so you can `ssh` in from
@@ -237,12 +361,15 @@ back up on its own — that's the real test, not just `systemctl start`.
   restarts it on its own. See [`deploy/systemd/README.md`](../deploy/systemd/README.md)
   for why this matters more than a plain restart policy.
 
-## 9. Troubleshooting
+## 10. Troubleshooting
 
 | Symptom | Check |
 |---|---|
 | `--list-audio` empty | See [Linux Notes](../README.md#linux-notes) — usually a missing PipeWire/Pulse compatibility layer |
-| Radio keys immediately on start | Confirm `ignore_initial_ptt_state: true`; check `journalctl` for "Ignoring initial PTT state" on startup |
-| Service won't come up after reboot | `journalctl --user -u zpttlink.service -b` — likely the USB device enumerated later than `serial_wait_timeout`; raise it in config.json (and `TimeoutStartSec` in the unit if you raise it a lot) |
+| **Standard node:** radio keys immediately on start | Confirm `ignore_initial_ptt_state: true`; check `journalctl` for "Ignoring initial PTT state" on startup |
+| **Standard node:** service won't come up after reboot | `journalctl --user -u zpttlink.service -b` — likely the USB device enumerated later than `serial_wait_timeout`; raise it in config.json (and `TimeoutStartSec` in the unit if you raise it a lot) |
+| **Standard node:** RX audio cuts out right as it starts relaying | You likely have RX wired to the same radio the backend keys for TX — see the wiring note in [RX Audio](../README.md#rx-audio-hardware-backends); use `ptt_output: "none"` for single-radio RX |
+| **Asterisk node:** no `PTT DOWN (asterisk-rx)` ever appears | Confirm Asterisk is actually sending USRP traffic to this host:port, and that nothing (a firewall, a NAT) is dropping UDP between the two |
+| **Asterisk node:** audio relays but Zello never transmits | You have `hotkey_enabled` off (`force_serial_ptt: true` or `--no-hotkey`) — the Asterisk backend needs hotkey injection to relay into Zello; see [step 7B](#7b-asterisk-node-configure-zpttlink-for-a-network-asterisk-backend) |
 | Zello never transmits, but `PTT DOWN` logs fine | You're likely on `injection_mode: adb` without Zello's hotkey set to **Toggle** — see [Android Runtime Targets](../README.md#android-runtime-targets) |
 | Random reboots when the repeater keys up | RFI — see the hardware section above; try ferrite chokes and re-check grounding before suspecting the Pi itself |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="zpttlink",
     version="3.0.0",
-    description="Open-source Zello <-> radio/Asterisk linking bridge: DTR/RTS/CM108 hardware PTT or Asterisk (USRP) over the network, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android",
+    description="ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android.",
     author="Max Hayim",
     packages=find_packages(),
     install_requires=[

--- a/zpttlink/gui.py
+++ b/zpttlink/gui.py
@@ -442,10 +442,36 @@ class MainWindow(QMainWindow):
         self.btn_refresh_audio = QPushButton("Refresh Audio")
         self.btn_refresh_audio.clicked.connect(self.refresh_audio_devices)
 
-        layout.addRow("Input", self.audio_in_combo)
-        layout.addRow("Output", self.audio_out_combo)
+        layout.addRow("TX Input (Zello → radio)", self.audio_in_combo)
+        layout.addRow("TX Output (Zello → radio)", self.audio_out_combo)
+
+        self.chk_rx_enabled = QCheckBox("Enable RX (radio → Zello)")
+        has_rx_cfg = self.cfg.get("rx_audio_input_index") is not None and self.cfg.get("rx_audio_output_index") is not None
+        self.chk_rx_enabled.setChecked(bool(has_rx_cfg))
+        self.chk_rx_enabled.toggled.connect(self._on_rx_enabled_toggled)
+        layout.addRow("", self.chk_rx_enabled)
+
+        self.rx_audio_in_combo = QComboBox()
+        self.rx_audio_out_combo = QComboBox()
+        layout.addRow("RX Input (from radio)", self.rx_audio_in_combo)
+        layout.addRow("RX Output (to Zello mic)", self.rx_audio_out_combo)
+
+        self.spin_rx_vox_threshold = QDoubleSpinBox()
+        self.spin_rx_vox_threshold.setRange(0.001, 1.000)
+        self.spin_rx_vox_threshold.setDecimals(3)
+        self.spin_rx_vox_threshold.setSingleStep(0.005)
+        self.spin_rx_vox_threshold.setValue(float(self.cfg.get("rx_vox", {}).get("threshold", 0.01)))
+        layout.addRow("RX VOX Threshold", self.spin_rx_vox_threshold)
+
         layout.addRow("", self.btn_refresh_audio)
+
+        self._on_rx_enabled_toggled(self.chk_rx_enabled.isChecked())
         return group
+
+    def _on_rx_enabled_toggled(self, checked: bool):
+        self.rx_audio_in_combo.setEnabled(checked)
+        self.rx_audio_out_combo.setEnabled(checked)
+        self.spin_rx_vox_threshold.setEnabled(checked)
 
     def _build_runtime_group(self):
         group = QGroupBox("Runtime")
@@ -611,9 +637,13 @@ class MainWindow(QMainWindow):
     def refresh_audio_devices(self):
         current_in_data = self.audio_in_combo.currentData()
         current_out_data = self.audio_out_combo.currentData()
+        current_rx_in_data = self.rx_audio_in_combo.currentData()
+        current_rx_out_data = self.rx_audio_out_combo.currentData()
 
         self.audio_in_combo.clear()
         self.audio_out_combo.clear()
+        self.rx_audio_in_combo.clear()
+        self.rx_audio_out_combo.clear()
 
         try:
             devices = sd.query_devices()
@@ -637,6 +667,8 @@ class MainWindow(QMainWindow):
         for dev_index, label in entries:
             self.audio_in_combo.addItem(label, dev_index)
             self.audio_out_combo.addItem(label, dev_index)
+            self.rx_audio_in_combo.addItem(label, dev_index)
+            self.rx_audio_out_combo.addItem(label, dev_index)
 
         self._restore_audio_combo(
             self.audio_in_combo,
@@ -649,6 +681,18 @@ class MainWindow(QMainWindow):
             current_out_data,
             self.cfg.get("audio_output_index"),
             self.cfg.get("audio_output"),
+        )
+        self._restore_audio_combo(
+            self.rx_audio_in_combo,
+            current_rx_in_data,
+            self.cfg.get("rx_audio_input_index"),
+            None,
+        )
+        self._restore_audio_combo(
+            self.rx_audio_out_combo,
+            current_rx_out_data,
+            self.cfg.get("rx_audio_output_index"),
+            None,
         )
 
         self.log("Audio devices refreshed.")
@@ -694,6 +738,17 @@ class MainWindow(QMainWindow):
         payload["ignore_initial_ptt_state"] = self.chk_ignore_initial_ptt.isChecked()
         payload["injection_mode"] = self.injection_mode_combo.currentText()
         payload["adb_serial"] = self.adb_serial_edit.text().strip() or None
+
+        if self.chk_rx_enabled.isChecked():
+            payload["rx_audio_input_index"] = self.rx_audio_in_combo.currentData()
+            payload["rx_audio_output_index"] = self.rx_audio_out_combo.currentData()
+        else:
+            payload["rx_audio_input_index"] = None
+            payload["rx_audio_output_index"] = None
+
+        rx_vox_cfg = dict(self.cfg.get("rx_vox", {}))
+        rx_vox_cfg["threshold"] = self.spin_rx_vox_threshold.value()
+        payload["rx_vox"] = rx_vox_cfg
         payload["radio_type"] = self.radio_type_combo.currentText()
         payload["asterisk"] = {
             "host": self.asterisk_host_edit.text().strip() or "127.0.0.1",
@@ -776,6 +831,13 @@ class MainWindow(QMainWindow):
 
         if self.audio_out_combo.currentData() is not None:
             args.extend(["--audio-output-index", str(self.audio_out_combo.currentData())])
+
+        if self.chk_rx_enabled.isChecked():
+            if self.rx_audio_in_combo.currentData() is not None:
+                args.extend(["--rx-audio-input-index", str(self.rx_audio_in_combo.currentData())])
+            if self.rx_audio_out_combo.currentData() is not None:
+                args.extend(["--rx-audio-output-index", str(self.rx_audio_out_combo.currentData())])
+            args.extend(["--rx-vox-threshold", str(self.spin_rx_vox_threshold.value())])
 
         return args
 

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -48,7 +48,9 @@ stop_event = threading.Event()
 keyboard = None
 logger = None
 audio_stream = None
+rx_audio_stream = None
 _last_level_log = 0.0
+_last_rx_level_log = 0.0
 
 if Key is not None:
     KEYMAP = {
@@ -193,6 +195,13 @@ DEFAULT_CONFIG = {
     "audio_input_index": None,
     "audio_output_index": None,
 
+    # RX audio path: the radio's received audio -> Zello's mic input. Only used by
+    # the hardware backends (DigiRig/CM108/Signalink) - the Asterisk backend is
+    # already full duplex over the network and doesn't use these. Leave both None
+    # to disable (TX-only, matching pre-3.1 behavior).
+    "rx_audio_input_index": None,
+    "rx_audio_output_index": None,
+
     "ptt_hotkey": DEFAULT_KEY,
     "ptt_output": "dtr",
     "ptt_active_low": False,
@@ -250,8 +259,21 @@ DEFAULT_CONFIG = {
         "log_levels": True
     },
 
+    # RX-side VOX: gates the radio -> Zello relay (see rx_audio_input/output_index
+    # above). The radio's receive-audio level characteristics can differ a lot from
+    # Zello's TX loopback level, so this is a separate threshold from `vox`.
+    "rx_vox": {
+        "enabled": True,
+        "threshold": 0.01,
+        "attack_ms": 20,
+        "release_ms": 150,
+        "hang_ms": 200,
+        "log_levels": True
+    },
+
     "audio": {
         "tx_gain": 0.08,
+        "rx_gain": 0.5,
         "samplerate": 48000,
         "limit": 0.90,
         "dc_block": True
@@ -1152,8 +1174,18 @@ def maybe_log_level(level, enabled):
         _last_level_log = now
 
 
+def maybe_log_rx_level(level, enabled):
+    global _last_rx_level_log
+    if not enabled:
+        return
+    now = time.monotonic()
+    if now - _last_rx_level_log >= 0.25:
+        logger.info(f"RX VOX level={level:.6f}")
+        _last_rx_level_log = now
+
+
 def main():
-    global keyboard, logger, audio_stream
+    global keyboard, logger, audio_stream, rx_audio_stream
 
     parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 3.0 Zello/radio/Asterisk bridge")
     parser.add_argument("--config", default=DEFAULT_CONFIG_FILE)
@@ -1196,6 +1228,23 @@ def main():
     parser.add_argument("--vox-attack-ms", type=int, default=None)
     parser.add_argument("--vox-release-ms", type=int, default=None)
     parser.add_argument("--vox-hang-ms", type=int, default=None)
+
+    parser.add_argument(
+        "--rx-audio-input-index",
+        type=int,
+        default=None,
+        help="RX path: device capturing the radio's received audio",
+    )
+    parser.add_argument(
+        "--rx-audio-output-index",
+        type=int,
+        default=None,
+        help="RX path: device feeding Zello's microphone input",
+    )
+    parser.add_argument("--rx-vox-threshold", type=float, default=None)
+    parser.add_argument("--rx-vox-attack-ms", type=int, default=None)
+    parser.add_argument("--rx-vox-release-ms", type=int, default=None)
+    parser.add_argument("--rx-vox-hang-ms", type=int, default=None)
 
     parser.add_argument("--ignore-initial-ptt-state", action="store_true")
     parser.add_argument("--force-serial-ptt", action="store_true")
@@ -1403,6 +1452,7 @@ def main():
 
     audio_cfg = cfg.get("audio", {})
     tx_gain = float(audio_cfg.get("tx_gain", 0.08))
+    rx_gain = float(audio_cfg.get("rx_gain", 0.5))
     configured_sr = int(audio_cfg.get("samplerate", 48000))
     limiter = float(audio_cfg.get("limit", 0.90))
     dc_block = bool(audio_cfg.get("dc_block", True))
@@ -1417,6 +1467,55 @@ def main():
     logger.info(
         f"TX gain: {tx_gain}, limiter: {limiter}, dc_block: {dc_block}"
     )
+
+    # RX audio path: radio's received audio -> Zello's mic input. Only meaningful
+    # for the hardware backends - the Asterisk backend is already full duplex over
+    # its own UDP stream and ignores these.
+    rx_input_index = args.rx_audio_input_index
+    if rx_input_index is None:
+        rx_input_index = cfg.get("rx_audio_input_index")
+
+    rx_output_index = args.rx_audio_output_index
+    if rx_output_index is None:
+        rx_output_index = cfg.get("rx_audio_output_index")
+
+    rx_enabled = (
+        not backend.transports_audio
+        and rx_input_index is not None
+        and rx_output_index is not None
+    )
+
+    rx_vox_cfg = cfg.get("rx_vox", {})
+    rx_vox_enabled = bool(rx_vox_cfg.get("enabled", True))
+    rx_vox_threshold = float(
+        args.rx_vox_threshold if args.rx_vox_threshold is not None else rx_vox_cfg.get("threshold", 0.01)
+    )
+    rx_vox_attack_ms = int(
+        args.rx_vox_attack_ms if args.rx_vox_attack_ms is not None else rx_vox_cfg.get("attack_ms", 20)
+    )
+    rx_vox_release_ms = int(
+        args.rx_vox_release_ms if args.rx_vox_release_ms is not None else rx_vox_cfg.get("release_ms", 150)
+    )
+    rx_vox_hang_ms = int(
+        args.rx_vox_hang_ms if args.rx_vox_hang_ms is not None else rx_vox_cfg.get("hang_ms", 200)
+    )
+    rx_vox_log_levels = bool(rx_vox_cfg.get("log_levels", False))
+
+    if rx_enabled:
+        logger.info(f"RX input index: {rx_input_index}")
+        logger.info(f"RX output index: {rx_output_index}")
+        logger.info(
+            "RX VOX: "
+            + ("enabled" if rx_vox_enabled else "disabled")
+            + f" threshold={rx_vox_threshold} attack={rx_vox_attack_ms}ms "
+            f"release={rx_vox_release_ms}ms hang={rx_vox_hang_ms}ms"
+        )
+        logger.info(f"RX gain: {rx_gain}")
+    elif not backend.transports_audio:
+        logger.info(
+            "RX audio disabled (set rx_audio_input_index/rx_audio_output_index in "
+            "config to relay the radio's received audio into Zello)."
+        )
 
     try:
         in_info = sd.query_devices(input_index)
@@ -1537,8 +1636,54 @@ def main():
             pass
         sys.exit(7)
 
+    if rx_enabled:
+        rx_gate = AudioGate(
+            threshold=rx_vox_threshold,
+            attack_ms=rx_vox_attack_ms,
+            release_ms=rx_vox_release_ms,
+            hang_ms=rx_vox_hang_ms,
+        )
+
+        def rx_audio_callback(indata, outdata, frames, time_info, status):
+            if status:
+                logger.warning(f"RX callback status: {status}")
+
+            level = rms_level(indata)
+            maybe_log_rx_level(level, rx_vox_log_levels)
+
+            try:
+                shaped = sanitize_audio(indata, tx_gain=rx_gain, limit=limiter, dc_block=dc_block)
+                outdata[:] = shaped
+            except Exception as e:
+                logger.error(f"RX audio shaping failed: {e}")
+                zero_out(outdata)
+
+            if not rx_vox_enabled:
+                return
+
+            action = rx_gate.process(level)
+            if action == "start":
+                ptt.down(source="radio-rx")
+            elif action == "stop":
+                ptt.up(source="radio-rx")
+
+        try:
+            rx_audio_stream = sd.Stream(
+                device=(rx_input_index, rx_output_index),
+                samplerate=samplerate,
+                channels=1,
+                dtype="float32",
+                callback=rx_audio_callback,
+            )
+            rx_audio_stream.start()
+            logger.info("RX audio stream active.")
+        except Exception as e:
+            logger.error(f"Failed to start RX stream (continuing TX-only): {e}")
+            rx_audio_stream = None
+
     logger.info(
-        f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, dry_run={args.dry_run})"
+        f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, "
+        f"rx_enabled={rx_enabled and rx_audio_stream is not None}, dry_run={args.dry_run})"
     )
     logger.info("ZPTTLink 3.0 bridge is running successfully! (Ctrl+C to exit)")
     sd_notify("READY=1")
@@ -1554,6 +1699,14 @@ def main():
             if audio_stream is not None and not audio_stream.active:
                 logger.error(
                     "Audio stream is no longer active (device disconnected or errored); "
+                    "exiting so the service manager can restart."
+                )
+                exit_code = 13
+                break
+
+            if rx_audio_stream is not None and not rx_audio_stream.active:
+                logger.error(
+                    "RX audio stream is no longer active (device disconnected or errored); "
                     "exiting so the service manager can restart."
                 )
                 exit_code = 13
@@ -1575,6 +1728,13 @@ def main():
             if audio_stream is not None:
                 audio_stream.stop()
                 audio_stream.close()
+        except Exception:
+            pass
+
+        try:
+            if rx_audio_stream is not None:
+                rx_audio_stream.stop()
+                rx_audio_stream.close()
         except Exception:
             pass
 

--- a/zpttlink/pyproject.toml
+++ b/zpttlink/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "zpttlink"
 # We read the version from the package to keep it in one place
 dynamic = ["version", "readme"]
-description = "Open-source Zello <-> radio/Asterisk linking bridge: DTR/RTS/CM108 hardware PTT or Asterisk (USRP) over the network, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android"
+description = "ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android."
 authors = [{ name = "Max Hayim" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

Closes the remaining TX-only gap: the hardware backends (DigiRig/CM108/Signalink) now support an independent **RX audio path** (radio's received audio → Zello's mic input), alongside the Asterisk backend, which was already full duplex. Off by default; opt in per-config so nothing changes for existing deployments.

Also restructures the Pi deployment tutorial into two explicit paths — **standard node** (physical radio) and **Asterisk node** (network USRP backend) — sharing common setup and diverging only where the config/hardware actually differs, and applies the maintainer's exact description text consistently across the README, GitHub repo description, `setup.py`, and `pyproject.toml`.

## RX audio

- New `rx_audio_input_index`/`rx_audio_output_index` config, a separate `rx_vox` gate (receive-audio levels rarely match the TX-side loopback level), and a new `audio.rx_gain`.
- Runs as a second, independent `sd.Stream` alongside the existing TX stream, reusing the same `AudioGate` mechanics already proven for TX VOX and the Asterisk backend. The RX gate's start/stop edges drive `ptt.down()`/`up(source="radio-rx")`, which is what triggers hotkey injection so relayed audio actually reaches Zello's network.
- **Important wiring caveat, documented in the README:** RX also calls the backend's own `ptt_on()`/`ptt_off()` — correct for a proper repeater topology with *separate* RX and TX radios, but wrong for a single transceiver (keying its own PTT mid-relay cuts off the very audio being relayed, since most transceivers mute RX while transmitting). Documented with a `ptt_output: "none"` workaround for single-radio setups.
- CLI: `--rx-audio-input-index`/`--rx-audio-output-index`/`--rx-vox-*`. GUI: RX device selectors, an Enable RX checkbox, and an RX VOX threshold spinbox.

## Docs

- README: new "RX Audio (Hardware Backends)" section, Known Limitations rewritten (the blanket TX-only note is gone), Features list updated, top description broadened beyond AIOC to also name CM108/DigiRig — the maintainer's exact wording is now used verbatim for the intro, matching the GitHub repo description/`setup.py`/`pyproject.toml`.
- `docs/raspberry-pi-repeater-deployment.md`: split into standard-node vs. Asterisk-node paths, each with its own hardware/config/troubleshooting rows, sharing the OS-flash/Waydroid+Zello/systemd steps that don't differ.

## Test plan

- [x] RX path verified end-to-end against real audio hardware: injected a 440Hz tone into a BlackHole loopback configured as `rx_audio_input_index`, confirmed RX VOX detected it (level jumped ~0.0004 → 0.21), correctly fired `PTT DOWN (radio-rx)` → real pynput key press → real `Serial PTT DTR -> ON`, and cleanly released on silence
- [x] Regression-tested the Asterisk backend: `rx_enabled` correctly `False` (Asterisk doesn't use these device indices, it's already duplex over its own stream), TX frame send unaffected — 106 USRP frames received by a mock peer in the same run as the earlier v3.0 PR
- [x] GUI: headless construction, checkbox toggle enabling/disabling the RX combos, config payload and CLI arg generation
- [x] `py_compile` across all touched files
- [ ] Not tested: a real dual-radio repeater topology (no hardware available here) — the wiring caveat above is reasoned from how transceivers behave, not observed on real duplicate hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)
