### PR TITLE
Merge AIOC into the one-liner description everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 <h1>ZPTTLink</h1>
 
-<p>ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android.</p>
+<p>ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android. Compatible radio interfaces include the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>, CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables — see <a href="#requirements">Requirements</a>.</p>
 
-<p>Compatible radio interfaces include the <a href="https://github.com/skuep/AIOC">AIOC (All-In-One Cable)</a>, CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables — see <a href="#requirements">Requirements</a>. Both the radio side and the Zello side are configurable independently: pick a hardware backend or <a href="#asterisk-usrp-backend">Asterisk (USRP)</a> for the radio side, and BlueStacks/Waydroid/docker-android for where Zello runs — see <a href="#android-runtime-targets">Android Runtime Targets</a>.</p>
+<p>Both the radio side and the Zello side are configurable independently: pick a hardware backend or <a href="#asterisk-usrp-backend">Asterisk (USRP)</a> for the radio side, and BlueStacks/Waydroid/docker-android for where Zello runs — see <a href="#android-runtime-targets">Android Runtime Targets</a>.</p>
 
 <p>This tool is ideal for GMRS and ham radio operators, emergency communications volunteers, and hobbyists who want to build a software-based radio gateway.</p>
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="zpttlink",
     version="3.0.0",
-    description="ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android.",
+    description="ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android. Compatible radio interfaces include the AIOC (All-In-One Cable), CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables.",
     author="Max Hayim",
     packages=find_packages(),
     install_requires=[

--- a/zpttlink/pyproject.toml
+++ b/zpttlink/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "zpttlink"
 # We read the version from the package to keep it in one place
 dynamic = ["version", "readme"]
-description = "ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android."
+description = "ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android. Compatible radio interfaces include the AIOC (All-In-One Cable), CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables."
 authors = [{ name = "Max Hayim" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

The short description string (setup.py, pyproject.toml, GitHub repo description) named DTR/RTS/CM108 but never AIOC explicitly, unlike the README which linked it separately in a second paragraph. Merged the two into one consistent description across all four locations.

GitHub's repo description field has a hard 350-char limit the full merged text exceeds by 16 characters, so that one spot uses a shortened interfaces clause ("AIOC, CM108/CM119, DigiRig, and more"). setup.py/pyproject.toml/README keep the full wording since they're not length-constrained — already applied directly (setup.py/pyproject.toml in this PR, GitHub repo description and this PR's README change together).

No code changes — descriptions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)