### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="zpttlink",
-    version="3.0.0",
+    version="3.1.0",
     description="ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android. Compatible radio interfaces include the AIOC (All-In-One Cable), CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables.",
     author="Max Hayim",
     packages=find_packages(),

--- a/zpttlink/__init__.py
+++ b/zpttlink/__init__.py
@@ -2,4 +2,4 @@
 ZPTTLink package initialization.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"

--- a/zpttlink/gui.py
+++ b/zpttlink/gui.py
@@ -42,7 +42,7 @@ except ImportError:
     from main import DEFAULT_CONFIG, list_audio_devices, list_serial_ports, load_config
 
 
-APP_TITLE = "ZPTTLink 3.0.0"
+APP_TITLE = "ZPTTLink 3.1.0"
 CONFIG_PATH = Path("config.json")
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -1187,7 +1187,7 @@ def maybe_log_rx_level(level, enabled):
 def main():
     global keyboard, logger, audio_stream, rx_audio_stream
 
-    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 3.0 Zello/radio/Asterisk bridge")
+    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 3.1 Zello/radio/Asterisk bridge")
     parser.add_argument("--config", default=DEFAULT_CONFIG_FILE)
     parser.add_argument("--key", help="Hotkey to send to Zello")
     parser.add_argument("--serial", help="Serial port override")
@@ -1685,7 +1685,7 @@ def main():
         f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, "
         f"rx_enabled={rx_enabled and rx_audio_stream is not None}, dry_run={args.dry_run})"
     )
-    logger.info("ZPTTLink 3.0 bridge is running successfully! (Ctrl+C to exit)")
+    logger.info("ZPTTLink 3.1 bridge is running successfully! (Ctrl+C to exit)")
     sd_notify("READY=1")
 
     exit_code = 0


### PR DESCRIPTION
Version strings still said 3.0.0 (set when the Asterisk backend landed), but RX audio for the hardware backends shipped in a later PR without a matching bump. 3.1.0 reflects what's actually in the tree, ahead of cutting the release.