### PR TITLE
feat: add Simulation Mode (radio_type: "simulate")

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
     </ul>
   </li>
   <li>Audio routing via <a href="https://vb-audio.com/Cable/">VB-Cable (Windows)</a>, <a href="https://existential.audio/blackhole/">BlackHole (macOS)</a>, or <a href="https://www.alsa-project.org/wiki/Loopback_Device">ALSA Loopback (Linux)</a></li>
+  <li><a href="#simulation-mode">Simulation Mode</a>: a fake radio/Asterisk peer for dev/testing/demos, with no real hardware or network traffic — a periodic synthetic tone burst by default, or a scripted, timed scenario file</li>
 </ul>
 
 <h2>Requirements</h2>
@@ -311,6 +312,52 @@ adb install /path/to/zello.apk</code></pre>
   <li><strong>Asterisk → Zello:</strong> incoming USRP voice frames are resampled up to the device rate and written into <code>audio_output_index</code> (point this at whatever virtual audio device feeds Zello's <em>microphone</em> input — the reverse role <code>audio_output_index</code> plays for the hardware backends, where it feeds the radio's TX audio input instead). The incoming frame's <code>keyup</code> field drives <code>ptt.down()</code>/<code>ptt.up()</code>, which is what triggers the hotkey injection that makes Zello actually transmit the relayed audio.</li>
 </ul>
 
+<h2>Simulation Mode</h2>
+
+<p>Set <code>radio_type: "simulate"</code> and ZPTTLink runs against a <strong>fake radio/Asterisk peer</strong> instead of real hardware or a real Asterisk instance — no serial device, no USB device, no socket, no network traffic at all. It's the exact same full-duplex pipeline as the <a href="#asterisk-usrp-backend">Asterisk backend</a> (same 20ms frames, same local VOX, same <code>keyup</code>-driven <code>ptt.down()</code>/<code>ptt.up()</code> hotkey injection into Zello), just fed synthetic RX audio instead of a real UDP peer. Useful for developing/testing ZPTTLink itself, demoing the full pipeline with nothing real connected, or exercising the GUI end-to-end (device pickers, PTT indicator, config editor) with no hardware on hand at all.</p>
+
+<h3>Configuration</h3>
+
+<pre><code>{
+  "radio_type": "simulate",
+  "force_serial_ptt": false,
+  "disable_hotkey": false,
+  "injection_mode": "auto",
+
+  "simulate": {
+    "interval_s": 10.0,
+    "burst_s": 2.0,
+    "tone_hz": 440.0,
+    "amplitude": 0.3,
+    "script": null,
+    "loop_script": true
+  }
+}
+</code></pre>
+
+<p>Or via the CLI: <code>python -m zpttlink --radio-type simulate --simulate-interval 10 --simulate-tone-hz 440</code>. In the GUI, pick "simulate" from the <strong>Radio Backend</strong> dropdown.</p>
+
+<p>Same as the Asterisk backend, this needs <code>force_serial_ptt: false</code> and a working <code>injection_mode</code> — there's no hardware line to key, so hotkey injection is what actually relays the synthetic RX audio into Zello.</p>
+
+<h3>Two ways to generate RX traffic</h3>
+
+<ul>
+  <li><strong>Periodic tone burst (default, no <code>script</code> set):</strong> every <code>interval_s</code> seconds, a synthetic <code>burst_s</code>-second tone at <code>tone_hz</code> is queued as RX audio with <code>keyup</code> toggling on/off around it — enough to exercise the RX relay path repeatedly without any setup.</li>
+  <li><strong>Scripted scenario (<code>script</code> set to a JSON file path):</strong> a deterministic, timed sequence of RX events instead of random/periodic traffic — for reproducing a specific test case or demoing a fixed scenario. See <a href="examples/simulate-scenario.json"><code>examples/simulate-scenario.json</code></a>:
+    <pre><code>{
+  "events": [
+    { "start_s": 2, "duration_s": 3, "tone_hz": 440, "amplitude": 0.3 },
+    { "start_s": 8, "duration_s": 1.5, "tone_hz": 880, "amplitude": 0.2 }
+  ]
+}
+</code></pre>
+    Each event's <code>start_s</code> is seconds from when ZPTTLink started (or from the start of the loop, if <code>loop_script</code> is true — the default). <code>tone_hz</code>/<code>amplitude</code> are optional per-event overrides of the top-level <code>simulate</code> config. Set <code>loop_script: false</code> (or <code>--simulate-no-loop</code>) to play the scenario once and then go quiet.</li>
+</ul>
+
+<h3>What it does <em>not</em> do</h3>
+
+<p>Simulation Mode never opens a socket and never touches a serial/USB device — <code>send_audio()</code> on this backend is always a no-op, regardless of the outbound <code>keyup</code> state. The only real side effect is whatever <code>injection_mode</code> is configured to do (a real keypress/ADB tap into your actual Zello target), which is the point — it lets you verify the injection path is wired correctly without needing the radio/Asterisk side to be real too.</p>
+
 <h2>RX Audio (Hardware Backends)</h2>
 
 <p>The DigiRig/CM108/Signalink backends now support a second, independent audio path: the radio's <em>received</em> audio relayed back into Zello. This is off by default (matching earlier versions) — set both <code>rx_audio_input_index</code> and <code>rx_audio_output_index</code> to enable it, or use the GUI's <strong>Enable RX (radio → Zello)</strong> checkbox in the Audio panel.</p>
@@ -345,7 +392,7 @@ adb install /path/to/zello.apk</code></pre>
 
 <p>Microphone/Zello audio is routed to the radio's audio output via a virtual audio driver, creating the Zello-to-RF link. If <a href="#rx-audio-hardware-backends">RX audio</a> is configured, the reverse leg (radio's received audio → Zello) runs as a second, independent stream, closing the loop into a full duplex bridge.</p>
 
-<p>The <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a> works differently from all of the above — audio flows over the network rather than to/from local devices; see that section for how it actually works in that mode.</p>
+<p>The <a href="#asterisk-usrp-backend">Asterisk (USRP) backend</a> works differently from all of the above — audio flows over the network rather than to/from local devices; see that section for how it actually works in that mode. <a href="#simulation-mode">Simulation Mode</a> runs that same code path against a fake peer instead of a real one — no hardware or network involved at all.</p>
 
 <h2>Known Limitations</h2>
 

--- a/examples/simulate-scenario.json
+++ b/examples/simulate-scenario.json
@@ -1,0 +1,7 @@
+{
+  "events": [
+    { "start_s": 2, "duration_s": 3, "tone_hz": 440, "amplitude": 0.3 },
+    { "start_s": 8, "duration_s": 1.5, "tone_hz": 880, "amplitude": 0.2 },
+    { "start_s": 12, "duration_s": 4, "tone_hz": 220, "amplitude": 0.35 }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="zpttlink",
-    version="3.1.0",
+    version="4.0.0",
     description="ZPTTLink is an open-source, all-in-one linking bridge. Deterministic DTR/RTS/CM108 hardware PTT or a network Asterisk (USRP) backend, with pynput/ydotool/ADB key injection for BlueStacks, Waydroid, and docker-android. Compatible radio interfaces include the AIOC (All-In-One Cable), CM108/CM119-based USB sound fobs, DigiRig, and other USB serial/audio radio cables.",
     author="Max Hayim",
     packages=find_packages(),

--- a/zpttlink/__init__.py
+++ b/zpttlink/__init__.py
@@ -2,4 +2,4 @@
 ZPTTLink package initialization.
 """
 
-__version__ = "3.1.0"
+__version__ = "4.0.0"

--- a/zpttlink/gui.py
+++ b/zpttlink/gui.py
@@ -42,7 +42,7 @@ except ImportError:
     from main import DEFAULT_CONFIG, list_audio_devices, list_serial_ports, load_config
 
 
-APP_TITLE = "ZPTTLink 3.1.0"
+APP_TITLE = "ZPTTLink 4.0.0"
 CONFIG_PATH = Path("config.json")
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -323,7 +323,7 @@ class MainWindow(QMainWindow):
         layout = QFormLayout(group)
 
         self.radio_type_combo = QComboBox()
-        self.radio_type_combo.addItems(["auto", "digirig", "cm108", "signalink", "asterisk"])
+        self.radio_type_combo.addItems(["auto", "digirig", "cm108", "signalink", "asterisk", "simulate"])
         self.radio_type_combo.setCurrentText(self.cfg.get("radio_type", "auto"))
         self.radio_type_combo.currentTextChanged.connect(self._on_radio_type_changed)
         layout.addRow("Radio Backend", self.radio_type_combo)
@@ -369,16 +369,62 @@ class MainWindow(QMainWindow):
         self.lbl_asterisk_hint.setWordWrap(True)
         layout.addRow("", self.lbl_asterisk_hint)
 
+        sim_cfg = self.cfg.get("simulate", {})
+        self.sim_interval_spin = QDoubleSpinBox()
+        self.sim_interval_spin.setRange(0.1, 3600.0)
+        self.sim_interval_spin.setSuffix(" s")
+        self.sim_interval_spin.setValue(float(sim_cfg.get("interval_s", 10.0)))
+        layout.addRow("Sim RX Interval", self.sim_interval_spin)
+
+        self.sim_burst_spin = QDoubleSpinBox()
+        self.sim_burst_spin.setRange(0.1, 300.0)
+        self.sim_burst_spin.setSuffix(" s")
+        self.sim_burst_spin.setValue(float(sim_cfg.get("burst_s", 2.0)))
+        layout.addRow("Sim RX Burst", self.sim_burst_spin)
+
+        self.sim_tone_spin = QDoubleSpinBox()
+        self.sim_tone_spin.setRange(20.0, 20000.0)
+        self.sim_tone_spin.setSuffix(" Hz")
+        self.sim_tone_spin.setValue(float(sim_cfg.get("tone_hz", 440.0)))
+        layout.addRow("Sim RX Tone", self.sim_tone_spin)
+
+        sim_script_row = QHBoxLayout()
+        self.sim_script_edit = QLineEdit(sim_cfg.get("script") or "")
+        self.sim_script_edit.setPlaceholderText("(none — periodic tone burst instead)")
+        self.btn_sim_script_browse = QPushButton("Browse")
+        self.btn_sim_script_browse.clicked.connect(self._browse_sim_script)
+        sim_script_row.addWidget(self.sim_script_edit, 1)
+        sim_script_row.addWidget(self.btn_sim_script_browse)
+        layout.addRow("Sim Script", self._wrap(sim_script_row))
+
+        self.lbl_sim_hint = QLabel(
+            "SIMULATION MODE: a fake radio/Asterisk peer — no real hardware or network "
+            "traffic. Runs the full pipeline against synthetic RX audio (a periodic "
+            "tone burst, or a scripted scenario file) for dev/testing/demos — see README."
+        )
+        self.lbl_sim_hint.setWordWrap(True)
+        layout.addRow("", self.lbl_sim_hint)
+
         self._on_radio_type_changed(self.radio_type_combo.currentText())
         return group
 
+    def _browse_sim_script(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Select Simulation Script", "", "JSON (*.json)")
+        if path:
+            self.sim_script_edit.setText(path)
+
     def _on_radio_type_changed(self, value: str):
         is_asterisk = value == "asterisk"
+        is_simulate = value == "simulate"
         for w in (self.serial_combo, self.btn_refresh_serial, self.ptt_mode_combo, self.chk_ignore_initial_ptt):
-            w.setEnabled(not is_asterisk)
+            w.setEnabled(not is_asterisk and not is_simulate)
         for w in (self.asterisk_host_edit, self.asterisk_port_spin):
             w.setEnabled(is_asterisk)
         self.lbl_asterisk_hint.setVisible(is_asterisk)
+        for w in (self.sim_interval_spin, self.sim_burst_spin, self.sim_tone_spin,
+                  self.sim_script_edit, self.btn_sim_script_browse):
+            w.setEnabled(is_simulate)
+        self.lbl_sim_hint.setVisible(is_simulate)
 
     def _build_android_target_group(self):
         group = QGroupBox("Android Target (Zello host)")
@@ -755,6 +801,14 @@ class MainWindow(QMainWindow):
             "port": self.asterisk_port_spin.value(),
             "local_port": self.cfg.get("asterisk", {}).get("local_port", 0),
         }
+        payload["simulate"] = {
+            "interval_s": self.sim_interval_spin.value(),
+            "burst_s": self.sim_burst_spin.value(),
+            "tone_hz": self.sim_tone_spin.value(),
+            "amplitude": self.cfg.get("simulate", {}).get("amplitude", 0.3),
+            "script": self.sim_script_edit.text().strip() or None,
+            "loop_script": self.cfg.get("simulate", {}).get("loop_script", True),
+        }
 
         payload["vox"] = {
             "enabled": self.chk_vox_enabled.isChecked(),
@@ -791,6 +845,13 @@ class MainWindow(QMainWindow):
         if radio_type == "asterisk":
             args.extend(["--asterisk-host", self.asterisk_host_edit.text().strip() or "127.0.0.1"])
             args.extend(["--asterisk-port", str(self.asterisk_port_spin.value())])
+        if radio_type == "simulate":
+            args.extend(["--simulate-interval", str(self.sim_interval_spin.value())])
+            args.extend(["--simulate-burst", str(self.sim_burst_spin.value())])
+            args.extend(["--simulate-tone-hz", str(self.sim_tone_spin.value())])
+            script = self.sim_script_edit.text().strip()
+            if script:
+                args.extend(["--simulate-script", script])
 
         if hotkey and not self.chk_no_hotkey.isChecked():
             args.extend(["--key", hotkey])

--- a/zpttlink/main.py
+++ b/zpttlink/main.py
@@ -240,6 +240,21 @@ DEFAULT_CONFIG = {
         "local_port": 0
     },
 
+    # radio_type: "simulate" is a fake radio/Asterisk peer - no hardware, no
+    # network traffic. Runs the same full-duplex pipeline as the Asterisk
+    # backend against synthetic RX audio, for dev/testing/demos with nothing
+    # real connected. With no "script" set, it generates a periodic tone burst
+    # every interval_s; with "script" set, it plays a scripted scenario file
+    # instead (see the Simulation Mode section of the README).
+    "simulate": {
+        "interval_s": 10.0,
+        "burst_s": 2.0,
+        "tone_hz": 440.0,
+        "amplitude": 0.3,
+        "script": None,
+        "loop_script": True
+    },
+
     "logging": {
         "level": "INFO",
         "file": DEFAULT_LOGFILE
@@ -780,6 +795,155 @@ class AsteriskRadio(RadioInterfaceBase):
             self.rx_thread = None
 
 
+class SimulatedRadio(RadioInterfaceBase):
+    """A fake radio/Asterisk peer - no real hardware, no real network traffic.
+    Exercises the exact same code path as AsteriskRadio (transports_audio=True,
+    the same 20ms USRP-shaped frames through send_audio()/recv_audio_nowait()),
+    so the full pipeline - local VOX, outbound framing, inbound keyup driving
+    ptt.down()/up() and hotkey injection - runs for real against synthetic
+    traffic instead of a live Asterisk instance. Nothing here ever touches a
+    socket or a hardware line, so it's inherently safe to run anywhere.
+
+    RX traffic is either a scripted scenario (a JSON file of timed events) or,
+    with no script configured, a periodic synthetic tone burst. See the
+    Simulation Mode section of the README for the script file format."""
+
+    name = "simulate"
+    transports_audio = True
+
+    def __init__(self, interval_s=10.0, burst_s=2.0, tone_hz=440.0, amplitude=0.3,
+                 script_path=None, loop_script=True):
+        self.interval_s = max(0.1, float(interval_s))
+        self.burst_s = max(0.1, float(burst_s))
+        self.tone_hz = float(tone_hz)
+        self.amplitude = max(0.0, min(1.0, float(amplitude)))
+        self.script_path = script_path
+        self.loop_script = bool(loop_script)
+        self.script_events = None
+        self.rx_queue = queue.Queue(maxsize=50)
+        self.gen_thread = None
+        self.stop_flag = threading.Event()
+
+    def open(self):
+        if self.script_path:
+            self.script_events = self._load_script(self.script_path)
+            logger.info(
+                f"SIMULATION MODE active - no real hardware or network connection. "
+                f"Playing scripted scenario from {self.script_path} "
+                f"({len(self.script_events)} events, loop={self.loop_script})."
+            )
+        else:
+            logger.info(
+                f"SIMULATION MODE active - no real hardware or network connection. "
+                f"Synthetic RX burst every {self.interval_s:.0f}s "
+                f"({self.burst_s:.1f}s @ {self.tone_hz:.0f}Hz)."
+            )
+        self.stop_flag.clear()
+        self.gen_thread = threading.Thread(target=self._generate_loop, daemon=True)
+        self.gen_thread.start()
+
+    @staticmethod
+    def _load_script(path):
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        events = data.get("events", []) if isinstance(data, dict) else data
+        if not events:
+            raise RuntimeError(f"Simulation script {path} has no events")
+        return sorted(events, key=lambda e: float(e.get("start_s", 0)))
+
+    def _generate_loop(self):
+        try:
+            if self.script_events:
+                self._run_script()
+            else:
+                self._run_periodic()
+        except Exception as e:
+            logger.error(f"SIMULATION MODE: generator stopped unexpectedly: {e}")
+
+    def _run_periodic(self):
+        while not self.stop_flag.wait(self.interval_s):
+            self._emit_burst(self.burst_s, self.tone_hz, self.amplitude)
+
+    def _run_script(self):
+        while not self.stop_flag.is_set():
+            t0 = time.monotonic()
+            for event in self.script_events:
+                target = t0 + float(event.get("start_s", 0))
+                while not self.stop_flag.is_set():
+                    remaining = target - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    self.stop_flag.wait(min(remaining, 0.5))
+                if self.stop_flag.is_set():
+                    return
+                self._emit_burst(
+                    float(event.get("duration_s", 1.0)),
+                    float(event.get("tone_hz", self.tone_hz)),
+                    max(0.0, min(1.0, float(event.get("amplitude", self.amplitude)))),
+                )
+            if not self.loop_script:
+                return
+
+    def _emit_burst(self, duration_s, tone_hz, amplitude):
+        logger.info(
+            f"SIMULATION MODE: synthetic RX keyup -> ON ({duration_s:.1f}s @ {tone_hz:.0f}Hz)"
+        )
+        n_frames = max(1, int(round(duration_s * USRP_SAMPLE_RATE / USRP_FRAME_SAMPLES)))
+        phase = 0.0
+        phase_inc = 2.0 * np.pi * tone_hz / USRP_SAMPLE_RATE
+        t = np.arange(USRP_FRAME_SAMPLES, dtype=np.float32)
+        frame_period = USRP_FRAME_SAMPLES / float(USRP_SAMPLE_RATE)
+        for _ in range(n_frames):
+            if self.stop_flag.is_set():
+                return
+            samples = (amplitude * np.sin(phase + phase_inc * t)).astype(np.float32)
+            phase = (phase + phase_inc * USRP_FRAME_SAMPLES) % (2.0 * np.pi)
+            self._push(samples, True)
+            self.stop_flag.wait(frame_period)
+        logger.info("SIMULATION MODE: synthetic RX keyup -> OFF")
+        self._push(np.zeros(USRP_FRAME_SAMPLES, dtype=np.float32), False)
+
+    def _push(self, samples, keyup):
+        item = (samples, keyup)
+        try:
+            self.rx_queue.put_nowait(item)
+        except queue.Full:
+            try:
+                self.rx_queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                self.rx_queue.put_nowait(item)
+            except queue.Full:
+                pass
+
+    def recv_audio_nowait(self):
+        try:
+            return self.rx_queue.get_nowait()
+        except queue.Empty:
+            return None
+
+    def send_audio(self, pcm16_array, keyup, dry=False):
+        # There is no real peer in simulation mode, so this is always a no-op -
+        # audio_callback already logs the local VOX keyup edge, and `dry` makes
+        # no difference here since nothing is ever actually sent either way.
+        pass
+
+    def ptt_on(self, dry=False):
+        if not dry:
+            logger.debug("SIMULATION MODE: relayed PTT DOWN (from synthetic keyup)")
+
+    def ptt_off(self, dry=False):
+        if not dry:
+            logger.debug("SIMULATION MODE: relayed PTT UP (from synthetic keyup)")
+
+    def close(self):
+        self.stop_flag.set()
+        if self.gen_thread is not None:
+            self.gen_thread.join(timeout=2.0)
+            self.gen_thread = None
+
+
 def choose_radio_type(cfg, args):
     explicit = getattr(args, "radio_type", None)
     if explicit:
@@ -877,6 +1041,24 @@ def build_radio_backend(cfg, args):
             else ast_cfg.get("local_port", 0)
         )
         return AsteriskRadio(host=host, port=port, local_port=local_port)
+
+    if radio_type == "simulate":
+        if np is None:
+            logger.error("numpy is required for Simulation Mode.")
+            sys.exit(2)
+        sim_cfg = cfg.get("simulate", {})
+        script_path = args.simulate_script or sim_cfg.get("script")
+        if script_path and not os.path.exists(script_path):
+            logger.error(f"Simulation script not found: {script_path}")
+            sys.exit(2)
+        return SimulatedRadio(
+            interval_s=args.simulate_interval if args.simulate_interval is not None else sim_cfg.get("interval_s", 10.0),
+            burst_s=args.simulate_burst if args.simulate_burst is not None else sim_cfg.get("burst_s", 2.0),
+            tone_hz=args.simulate_tone_hz if args.simulate_tone_hz is not None else sim_cfg.get("tone_hz", 440.0),
+            amplitude=args.simulate_amplitude if args.simulate_amplitude is not None else sim_cfg.get("amplitude", 0.3),
+            script_path=script_path,
+            loop_script=(not args.simulate_no_loop) and bool(sim_cfg.get("loop_script", True)),
+        )
 
     if radio_type == "signalink":
         return SignalinkRadio()
@@ -1187,7 +1369,7 @@ def maybe_log_rx_level(level, enabled):
 def main():
     global keyboard, logger, audio_stream, rx_audio_stream
 
-    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 3.1 Zello/radio/Asterisk bridge")
+    parser = argparse.ArgumentParser(prog="zpttlink", description="ZPTTLink 4.0 Zello/radio/Asterisk bridge")
     parser.add_argument("--config", default=DEFAULT_CONFIG_FILE)
     parser.add_argument("--key", help="Hotkey to send to Zello")
     parser.add_argument("--serial", help="Serial port override")
@@ -1201,7 +1383,7 @@ def main():
     parser.add_argument("--baud", type=int, default=None)
     parser.add_argument(
         "--radio-type",
-        choices=["auto", "cm108", "digirig", "signalink", "asterisk"],
+        choices=["auto", "cm108", "digirig", "signalink", "asterisk", "simulate"],
         default=None,
     )
     parser.add_argument("--ptt-output", choices=["none", "dtr", "rts"], default=None)
@@ -1213,6 +1395,17 @@ def main():
         default=None,
         help="Local UDP port to bind for the Asterisk USRP backend (0 = OS-assigned)",
     )
+    parser.add_argument(
+        "--simulate-script",
+        default=None,
+        help="Path to a Simulation Mode scenario JSON file (--radio-type simulate). "
+        "Omit for a periodic synthetic tone burst instead.",
+    )
+    parser.add_argument("--simulate-interval", type=float, default=None, help="Seconds between synthetic RX bursts (no script)")
+    parser.add_argument("--simulate-burst", type=float, default=None, help="Synthetic RX burst duration in seconds (no script)")
+    parser.add_argument("--simulate-tone-hz", type=float, default=None, help="Synthetic RX tone frequency in Hz")
+    parser.add_argument("--simulate-amplitude", type=float, default=None, help="Synthetic RX tone amplitude (0.0-1.0)")
+    parser.add_argument("--simulate-no-loop", action="store_true", help="Play a Simulation Mode script once instead of looping")
     parser.add_argument("--no-hotkey", action="store_true")
     parser.add_argument("--test-ptt", action="store_true")
     parser.add_argument("--list-serial", action="store_true")
@@ -1539,14 +1732,16 @@ def main():
     usrp_remote_keyed = [False]
 
     if backend.transports_audio:
+        _peer_label = "Asterisk" if backend.name == "asterisk" else "the simulated peer"
         logger.info(
-            f"Asterisk USRP mode: local audio keys Asterisk directly; incoming Asterisk "
-            f"keyup relays into Zello via {'hotkey injection' if hotkey_enabled else 'PTT UP/DOWN log only (hotkey injection disabled!)'}."
+            f"{'Asterisk USRP' if backend.name == 'asterisk' else 'Simulation'} mode: "
+            f"local audio keys {_peer_label} directly; incoming keyup relays into Zello via "
+            f"{'hotkey injection' if hotkey_enabled else 'PTT UP/DOWN log only (hotkey injection disabled!)'}."
         )
         if not hotkey_enabled:
             logger.warning(
-                "hotkey_enabled is False with radio_type=asterisk: audio arriving from "
-                "Asterisk will be written into Zello's mic input, but Zello won't be told "
+                f"hotkey_enabled is False with radio_type={backend.name}: audio arriving from "
+                f"{_peer_label} will be written into Zello's mic input, but Zello won't be told "
                 "to transmit it unless Zello's own VOX is enabled. Set force_serial_ptt: "
                 "false and configure injection_mode to relay it properly."
             )
@@ -1582,10 +1777,10 @@ def main():
                 rx_samples, rx_keyup = rx
                 if rx_keyup and not usrp_remote_keyed[0]:
                     usrp_remote_keyed[0] = True
-                    ptt.down(source="asterisk-rx")
+                    ptt.down(source=f"{backend.name}-rx")
                 elif not rx_keyup and usrp_remote_keyed[0]:
                     usrp_remote_keyed[0] = False
-                    ptt.up(source="asterisk-rx")
+                    ptt.up(source=f"{backend.name}-rx")
                 up = resample_linear(rx_samples, USRP_SAMPLE_RATE, samplerate)
                 outdata[:] = fit_frame(up, frames)
             else:
@@ -1685,7 +1880,7 @@ def main():
         f"PTT system ready (radio_backend={backend.name}, hotkey_enabled={hotkey_enabled}, "
         f"rx_enabled={rx_enabled and rx_audio_stream is not None}, dry_run={args.dry_run})"
     )
-    logger.info("ZPTTLink 3.1 bridge is running successfully! (Ctrl+C to exit)")
+    logger.info("ZPTTLink 4.0 bridge is running successfully! (Ctrl+C to exit)")
     sd_notify("READY=1")
 
     exit_code = 0


### PR DESCRIPTION
## Summary
- New `radio_type: "simulate"` backend: a fake radio/Asterisk peer, no real hardware or network traffic at all.
- Reuses the exact same full-duplex pipeline as the Asterisk (USRP) backend — same 20ms frames, local VOX, `keyup`-driven `ptt.down()`/`ptt.up()` hotkey injection into Zello — fed synthetic RX audio instead of a real UDP peer, so it exercises the whole path (including the GUI) with nothing real connected.
- Two ways to drive RX traffic: a periodic synthetic tone burst by default, or a scripted, timed scenario file (`examples/simulate-scenario.json`).
- `send_audio()` on this backend is always a no-op — no socket, no serial/USB device, ever touched, regardless of `--dry-run`.
- CLI flags (`--simulate-interval/--simulate-burst/--simulate-tone-hz/--simulate-amplitude/--simulate-script/--simulate-no-loop`), config block, and a GUI "simulate" Radio Backend entry with its own field group (interval/burst/tone/script + Browse button).
- Generalized two previously Asterisk-hardcoded bits so they read correctly for Simulate too: the `transports_audio` startup log banner, and the RX-keyup `ptt.down()`/`ptt.up()` `source=` tag (was `"asterisk-rx"`, now `f"{backend.name}-rx"`).
- README: new Simulation Mode section (config, the two RX-traffic modes, what it deliberately doesn't do), a Features bullet, and a How It Works cross-reference.
- Version bump to 4.0.0 across `setup.py`/`__init__.py`/GUI title/CLI banner.

## Test plan
- [x] `py_compile` on all four changed Python files
- [x] Unit-level exercise of `SimulatedRadio` directly: periodic burst mode produces RX frames with both `keyup` True→False transitions; scripted scenario file loads/sorts/parses correctly; `send_audio()` is a safe no-op even after `close()`
- [x] `build_radio_backend()` wired end-to-end: `radio_type=simulate` returns a `SimulatedRadio` with `transports_audio=True`; a missing `--simulate-script` path exits(2) as expected
- [x] `python -m zpttlink --radio-type simulate --simulate-interval 5 --simulate-tone-hz 500` parses and starts without error
- Not tested: the GUI panel itself (no display in this environment) and the full `sd.Stream` audio path end-to-end — both reuse existing, already-tested code paths (the Asterisk backend's GUI fields and `transports_audio` audio_callback branch), so risk is low, but flagging per the project's own "nothing tested on real hardware" convention